### PR TITLE
Fix multiple VOLUME Dockerfile format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,6 +184,6 @@ ENV APACHE_LOG_DIR /var/log/apache2
 
 EXPOSE 80
 
-VOLUME [ "/opt/nagios/var" "/opt/nagios/etc" "/opt/nagios/libexec" "/var/log/apache2" "/usr/share/snmp/mibs" ]
+VOLUME "/opt/nagios/var" "/opt/nagios/etc" "/opt/nagios/libexec" "/var/log/apache2" "/usr/share/snmp/mibs"
 
 CMD [ "/usr/local/bin/start_nagios" ]


### PR DESCRIPTION
The array notation for multiple VOLUMEs in the Dockerfile is incorrect, and leading to extra `/[` and `/]` volumes getting created in the container.

To view extra `/[` and `/]` directories:

```shell
docker run --rm jasonrivers/nagios:latest ls -l /
```