### PR TITLE
Copy /etc/resolv.conf to chrooted postfix for relay hostname resolution

### DIFF
--- a/postfix.init
+++ b/postfix.init
@@ -6,4 +6,7 @@
 sed -i "s/relayhost =.*/relayhost = ${MAIL_SERVER}/" /etc/postfix/main.cf
 sed -i "s/myhostname =.*/myhostname = `hostname`/" /etc/postfix/main.cf
 
+#postfix runs in a chroot and needs resolv.conf to resolve hostnames
+cp /etc/resolv.conf /var/spool/postfix/etc/resolv.conf
+
 exec /usr/lib/postfix/sbin/master -d -c /etc/postfix


### PR DESCRIPTION
This PR augments postfix.init by copying `/etc/resolv.conf` to postfix's chroot (`/var/spool/postfix/etc/resolv.conf`) before postfix starts, allowing it to resolve hostnames including SMTP relay hosts.

It would probably be worthwhile to mention that you can set the `MAIL_PORT_25_TCP_ADDR` environment variable to an SMTP relaying host to set up SMTP forwarding. Could be in the README and/or declared as an `ENV` in the Dockerfile.

It also took me a while to figure out that I needed to install `rsyslog`, start the `rsyslog` service, and watch `/var/log/syslog` to debug postfix problems, so that may be worth mentioning in the README.

Thanks!