### PR TITLE
Update /etc/default apache include for Ubuntu 16.04

### DIFF
--- a/apache.init
+++ b/apache.init
@@ -1,6 +1,6 @@
 #!/bin/bash
 . /etc/apache2/envvars
 
-. /etc/default/apache2
+. /etc/default/apache-htcacheclean
 
 exec /usr/sbin/apache2 -D FOREGROUND


### PR DESCRIPTION
`/etc/default/apache2` has been moved to `/etc/default/apache-htcacheclean` in Ubuntu 16.04.