### PR TITLE
Remove postfix.stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,7 +175,6 @@ ADD nagios/localhost.cfg /opt/nagios/etc/objects/localhost.cfg
 ADD nagios.init /etc/sv/nagios/run
 ADD apache.init /etc/sv/apache/run
 ADD postfix.init /etc/sv/postfix/run
-ADD postfix.stop /etc/sv/postfix/finish
 ADD start.sh /usr/local/bin/start_nagios
 RUN chmod +x /usr/local/bin/start_nagios
 

--- a/postfix.stop
+++ b/postfix.stop
@@ -1,1 +1,0 @@
-postfix stop


### PR DESCRIPTION
I don't believe `/etc/sv/postfix/finish` is needed, as the postfix processes terminate normally without it when `sv stop /etc/sv/postfix` is run, and when it is present the following error is produced:

```
postfix/postfix-script: fatal: the Postfix mail system is not running
```

If you decide to keep it, it needs a hashbang at the top
```
#!/bin/sh
```

runit is complaining about the format without the hashbang:

```
runsv postfix: fatal: unable to start ./finish: exec format error
```