### PR TITLE
Handle signals in start_nagios, run apache in runit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN	sed -i 's/universe/universe multiverse/' /etc/apt/sources.list	;\
 		fping							\
 		libfreeradius-client-dev				\
 		libnet-snmp-perl					\
-		libnet-xmpp-perl				&&	\
+		libnet-xmpp-perl					\
+		parallel					&&	\
 		apt-get clean
 
 RUN	( egrep -i "^${NAGIOS_GROUP}"    /etc/group || groupadd $NAGIOS_GROUP    )				&&	\
@@ -161,10 +162,7 @@ RUN	sed -i 's,/bin/mail,/usr/bin/mail,' /opt/nagios/etc/objects/commands.cfg		&&
 
 RUN	cp /etc/services /var/spool/postfix/etc/
 
-RUN	mkdir -p /etc/sv/nagios								&&	\
-	mkdir -p /etc/sv/apache								&&	\
-	rm -rf /etc/sv/getty-5								&&	\
-	mkdir -p /etc/sv/postfix
+RUN	rm -rf /etc/sv/getty-5
 
 ADD nagios/nagios.cfg /opt/nagios/etc/nagios.cfg
 ADD nagios/cgi.cfg /opt/nagios/etc/cgi.cfg
@@ -178,6 +176,9 @@ ADD postfix.init /etc/sv/postfix/run
 ADD postfix.stop /etc/sv/postfix/finish
 ADD start.sh /usr/local/bin/start_nagios
 RUN chmod +x /usr/local/bin/start_nagios
+
+# enable all runit services
+RUN ln -s /etc/sv/* /etc/service
 
 ENV APACHE_LOCK_DIR /var/run
 ENV APACHE_LOG_DIR /var/log/apache2

--- a/apache.init
+++ b/apache.init
@@ -3,4 +3,5 @@
 
 . /etc/default/apache2
 
-exec /usr/sbin/apache2 -D FOREGROUND
+#exec /usr/sbin/apache2 -D FOREGROUND
+exec /usr/sbin/apache2 -D NO_DETACH

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,36 @@
 #!/bin/bash
 
+# adapted from https://github.com/discourse/discourse_docker/blob/master/image/base/boot
+# this script becomes PID 1 inside the container, catches termination signals, and stops
+# processes managed by runit
+
 if [ ! -f ${NAGIOS_HOME}/etc/htpasswd.users ] ; then
   htpasswd -c -b -s ${NAGIOS_HOME}/etc/htpasswd.users ${NAGIOSADMIN_USER} ${NAGIOSADMIN_PASS}
   chown -R nagios.nagios ${NAGIOS_HOME}/etc/htpasswd.users
 fi
 
-exec runsvdir /etc/sv
+shutdown() {
+  echo Shutting Down
+  ls /etc/service | SHELL=/bin/sh parallel --no-notice sv force-stop {}
+  if [ -e /proc/$RUNSVDIR ]; then
+    kill -HUP $RUNSVDIR
+    wait $RUNSVDIR
+  fi
 
-/etc/init.d/apache2 start
+  # give stuff a bit of time to finish
+  sleep 1
+
+  ORPHANS=`ps -eo pid | grep -v PID  | tr -d ' ' | grep -v '^1$'`
+  SHELL=/bin/bash parallel --no-notice 'timeout 5 /bin/bash -c "kill {} && wait {}" || kill -9 {}' ::: $ORPHANS 2> /dev/null
+  exit
+}
+
+exec runsvdir -P /etc/service &
+RUNSVDIR=$!
+echo "Started runsvdir, PID is $RUNSVDIR"
+
+trap shutdown SIGTERM SIGHUP SIGINT
+wait $RUNSVDIR
+
+shutdown
+


### PR DESCRIPTION
I noticed a few issues with this image:

1. Even when I mounted the `/opt/nagios/var` volume to a host or named volume, I couldn't get Nagios host/service statuses and config tweaks (notifications disabled, problem acknowledgements, etc) to persist across restarts. After investigating I realized that this was because the nagios process wasn't being gracefully shut down when the container exits, which never allowed it to write `/opt/nagios/var/retention.dat` (which holds the status info that gets loaded on startup).
2. When running the container interactively (`-it`), pressing Ctrl-C wouldn't stop the container...processes would just respawn. To stop the container you had to issue a `docker stop nagios` from another terminal.

There are some issues with using runit inside of Docker, namely that `runsvdir` will immediately exit with 0 when it gets `SIGTERM`, i.e. it doesn't forward the signal on to the services it's managing and wait for them to terminate. Thus the problem with nagios never receiving the signal and having the opportunity to create `retention.dat`.

https://peter.bourgon.org/blog/2015/09/24/docker-runit-and-graceful-termination.html
https://github.com/docker/docker/issues/8485

This PR borrows heavily from the wrapper `CMD` script here:

https://github.com/discourse/discourse_docker/blob/master/image/base/boot

Basic idea is that the bash script acts as PID 1 in the container and listens for signals. When it receives a termination signal, it shuts down any processes being run by runit before it exits. This allows nagios the opportunity to cleanly shut down and create `retention.dat` (tested, and it works!).

This also runs apache in runit (using `NO_DETACH` instead of `FOREGROUND` seemed to do the trick).