### PR TITLE
Fix Missing Dependencies for WL Nagios Plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,13 @@ RUN	sed -i 's/universe/universe multiverse/' /etc/apt/sources.list	;\
 		libfreeradius-client-dev				\
 		libnet-snmp-perl					\
 		libnet-xmpp-perl					\
-		parallel					&&	\
+		parallel					\
+		libcache-memcached-perl	\
+		libdbd-mysql-perl	\
+		libdbi-perl	\
+		libnet-tftp-perl	\
+		libredis-perl	\
+		libswitch-perl &&	\
 		apt-get clean
 
 RUN	( egrep -i "^${NAGIOS_GROUP}"    /etc/group || groupadd $NAGIOS_GROUP    )				&&	\
@@ -101,7 +107,9 @@ RUN	cd /tmp							&&	\
 		--prefix=${NAGIOS_HOME}				&&	\
 	make							&&	\
 	make install						&&	\
-	make clean
+	make clean	&&	\
+	mkdir -p /usr/lib/nagios/plugins	&&	\
+	ln -sf /opt/nagios/libexec/utils.pm /usr/lib/nagios/plugins
 
 RUN	cd /tmp							&&	\
 	git clone https://github.com/NagiosEnterprises/nrpe.git	&&	\
@@ -123,7 +131,7 @@ RUN	cd /tmp											&&	\
 		--www-user ${NAGIOS_USER}								\
 		--nagios-perfdata-file ${NAGIOS_HOME}/var/perfdata.log					\
 		--nagios-cgi-url /cgi-bin							&&	\
-	cp share/nagiosgraph.ssi ${NAGIOS_HOME}/share/ssi/common-header.ssi			
+	cp share/nagiosgraph.ssi ${NAGIOS_HOME}/share/ssi/common-header.ssi
 
 RUN cd /opt &&		\
 	git clone https://github.com/willixix/WL-NagiosPlugins.git	WL-Nagios-Plugins	&&	\


### PR DESCRIPTION
A number of the plugins in `/opt/WL-Nagios-Plugins` fail to execute due to missing libraries. This PR resolves the following:

```
Can't locate Cache/Memcached.pm in @INC (you may need to install the Cache::Memcached module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /opt/WL-Nagios-Plugins/check_memcached.pl line 362.
BEGIN failed--compilation aborted at /opt/WL-Nagios-Plugins/check_memcached.pl line 362.
```

```
Can't locate DBI.pm in @INC (you may need to install the DBI module) (@INC contains: /usr/lib/nagios/plugins /usr/local/mysql/modules /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /opt/WL-Nagios-Plugins/check_mysqld.pl line 216.
BEGIN failed--compilation aborted at /opt/WL-Nagios-Plugins/check_mysqld.pl line 216.
```

```
Can't locate check_snmp_attributes.pl in @INC (@INC contains: /usr/lib/nagios/plugins /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /opt/WL-Nagios-Plugins/check_netsnmp_memory.pl line 80.
```

```
Can't locate check_snmp_attributes.pl in @INC (@INC contains: /usr/lib/nagios/plugins /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /opt/WL-Nagios-Plugins/check_netsnmp_memory_15.pl line 72.
```

```
Can't locate Switch.pm in @INC (you may need to install the Switch module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /opt/WL-Nagios-Plugins/check_netstat.pl line 202.
BEGIN failed--compilation aborted at /opt/WL-Nagios-Plugins/check_netstat.pl line 202.
```

```
Can't locate Redis.pm in @INC (you may need to install the Redis module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /opt/WL-Nagios-Plugins/check_redis.pl line 421.
BEGIN failed--compilation aborted at /opt/WL-Nagios-Plugins/check_redis.pl line 421.
```

```
Can't locate utils.pm in @INC (you may need to install the utils module) (@INC contains: /usr/lib/nagios/plugins /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /opt/WL-Nagios-Plugins/check_snmp_dell_powersupply.pl line 86.
BEGIN failed--compilation aborted at /opt/WL-Nagios-Plugins/check_snmp_dell_powersupply.pl line 86.
```

```
Can't locate utils.pm in @INC (you may need to install the utils module) (@INC contains: /usr/lib/nagios/plugins /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /opt/WL-Nagios-Plugins/check_snmp_table.pl line 172.
BEGIN failed--compilation aborted at /opt/WL-Nagios-Plugins/check_snmp_table.pl line 172.
```

```
Can't locate Net/TFTP.pm in @INC (you may need to install the Net::TFTP module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /opt/WL-Nagios-Plugins/check_tftp.pl line 61.
BEGIN failed--compilation aborted at /opt/WL-Nagios-Plugins/check_tftp.pl line 61.
```