### PR TITLE
Fix empty etc, var checks

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,12 +4,12 @@
 # this script becomes PID 1 inside the container, catches termination signals, and stops
 # processes managed by runit
 
-if ! [ $(ls -A /opt/nagios/etc) ]; then
+if [ -z "$(ls -A /opt/nagios/etc)" ]; then
     echo "Started with emty ETC, copying example data in-place"
     cp -Rp /orig/etc/* /opt/nagios/etc/
 fi
 
-if ! [ $(ls -A /opt/nagios/var) ]; then
+if [ -z "$(ls -A /opt/nagios/var)" ]; then
     echo "Started with emty VAR, copying example data in-place"
     cp -Rp /orig/var/* /opt/nagios/var/
 fi


### PR DESCRIPTION
The current checks for empty `/opt/nagios/etc` and `/opt/nagios/var` directories are invalid and cause errors, resulting in the example data being copied every time:

```
/usr/local/bin/start_nagios: line 7: [: too many arguments
Started with emty ETC, copying example data in-place
/usr/local/bin/start_nagios: line 12: [: rw: binary operator expected
Started with emty VAR, copying example data in-place
```

This commit fixes those checks. Tested with both empty and non-empty etc and var dirs.