### PR TITLE
[Dockerfile] --with-nagios-command-user does not exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN	cd /tmp							&&	\
 		--prefix=${NAGIOS_HOME}					\
 		--exec-prefix=${NAGIOS_HOME}				\
 		--enable-event-broker					\
-		--with-nagios-command-user=${NAGIOS_CMDUSER}		\
+		--with-command-user=${NAGIOS_CMDUSER}			\
 		--with-command-group=${NAGIOS_CMDGROUP}			\
 		--with-nagios-user=${NAGIOS_USER}			\
 		--with-nagios-group=${NAGIOS_GROUP}		&&	\


### PR DESCRIPTION
_Nagios_ command-line argument `--with-nagios-command-user` does not exist in _Nagios_ version 4.2.4 .

Solution: replace `--with-nagios-command-user` by `--with-command-user`.

Reference: https://github.com/NagiosEnterprises/nagioscore/blob/release-4.2.4/configure#L1392