### PR TITLE
[Dockerfile] make install-webconf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,7 @@ RUN	cd /tmp							&&	\
 	make install						&&	\
 	make install-config					&&	\
 	make install-commandmode				&&	\
-	cp sample-config/httpd.conf /etc/apache2/conf-available/nagios.conf	&&	\
-	ln -s /etc/apache2/conf-available/nagios.conf /etc/apache2/conf-enabled/nagios.conf		&&	\
+	make install-webconf					&&	\
 	make clean
 
 RUN	cd /tmp							&&	\


### PR DESCRIPTION
Replace custom commands by `make install-webconf`.

Console output is:
```sh
/usr/bin/install -c -m 644 sample-config/httpd.conf /etc/apache2/sites-available/nagios.conf
if [ 1 -eq 1 ]; then \
	ln -s /etc/apache2/sites-available/nagios.conf /etc/apache2/sites-enabled/nagios.conf; \
fi

*** Nagios/Apache conf file installed ***
```