### PR TITLE
WARNING: The normal_check_interval attribute is deprecated and will be removed in future versions. Please use check_interval instead.

### DIFF
--- a/nagios/templates.cfg
+++ b/nagios/templates.cfg
@@ -164,7 +164,7 @@ define service{
         is_volatile                     0       		; The service is not volatile
         check_period                    24x7			; The service can be checked at any time of the day
         max_check_attempts              3			; Re-check the service up to 3 times in order to determine its final (hard) state
-        check_interval           10				; Check the service every 10 minutes under normal conditions
+        check_interval           	10			; Check the service every 10 minutes under normal conditions
         retry_check_interval            2			; Re-check the service every two minutes until a hard state can be determined
         contact_groups                  admins			; Notifications get sent out to everyone in the 'admins' group
 	notification_options		w,u,c,r			; Send notifications about warning, unknown, critical, and recovery events
@@ -180,7 +180,7 @@ define service{
 	name				local-service 		; The name of this service template
 	use				generic-service		; Inherit default values from the generic-service definition
         max_check_attempts              4			; Re-check the service up to 4 times in order to determine its final (hard) state
-        check_interval           5				; Check the service every 5 minutes under normal conditions
+        check_interval           	5			; Check the service every 5 minutes under normal conditions
         retry_check_interval            1			; Re-check the service every minute until a hard state can be determined
         register                        0       		; DONT REGISTER THIS DEFINITION - ITS NOT A REAL SERVICE, JUST A TEMPLATE!
 	}

--- a/nagios/templates.cfg
+++ b/nagios/templates.cfg
@@ -164,7 +164,7 @@ define service{
         is_volatile                     0       		; The service is not volatile
         check_period                    24x7			; The service can be checked at any time of the day
         max_check_attempts              3			; Re-check the service up to 3 times in order to determine its final (hard) state
-        normal_check_interval           10			; Check the service every 10 minutes under normal conditions
+        check_interval           10				; Check the service every 10 minutes under normal conditions
         retry_check_interval            2			; Re-check the service every two minutes until a hard state can be determined
         contact_groups                  admins			; Notifications get sent out to everyone in the 'admins' group
 	notification_options		w,u,c,r			; Send notifications about warning, unknown, critical, and recovery events
@@ -180,7 +180,7 @@ define service{
 	name				local-service 		; The name of this service template
 	use				generic-service		; Inherit default values from the generic-service definition
         max_check_attempts              4			; Re-check the service up to 4 times in order to determine its final (hard) state
-        normal_check_interval           5			; Check the service every 5 minutes under normal conditions
+        check_interval           5				; Check the service every 5 minutes under normal conditions
         retry_check_interval            1			; Re-check the service every minute until a hard state can be determined
         register                        0       		; DONT REGISTER THIS DEFINITION - ITS NOT A REAL SERVICE, JUST A TEMPLATE!
 	}


### PR DESCRIPTION
Replace `normal_check_interval` by `check_interval` in Nagios template to fix following WARNING (since Nagios 4.3.0 NagiosEnterprises/nagioscore@de2a8a0d9941acef2be876660437afc2047dde50)
> WARNING: The normal_check_interval attribute is deprecated and will be removed in future versions. Please use check_interval instead.

