### PR TITLE
Change inet_protocols to ipv4

### DIFF
--- a/postfix.init
+++ b/postfix.init
@@ -4,6 +4,7 @@
 sed -i "s/relayhost =.*/relayhost = ${MAIL_RELAY_HOST}/" /etc/postfix/main.cf
 sed -i "s/myhostname =.*/myhostname = `hostname`/" /etc/postfix/main.cf
 sed -i "s/mydestination =.*/mydestination = ${NAGIOS_FQDN}, \$myhostname, localhost.localdomain, localhost/" /etc/postfix/main.cf
+sed -i "s/inet_protocols =.*/inet_protocols = ipv4/" /etc/postfix/main.cf
 
 sed -i "/^myorigin =.*/d" /etc/postfix/main.cf
 echo "${NAGIOS_FQDN}" > /etc/mailname


### PR DESCRIPTION
Force inet_protocols to ipv4 to fix these warnings:

```
postfix/sendmail[200]: warning: inet_protocols: disabling IPv6 name/address support: Address family not supported by protocol
postfix/postdrop[201]: warning: inet_protocols: disabling IPv6 name/address support: Address family not supported by protocol
postfix/cleanup[202]: warning: inet_protocols: disabling IPv6 name/address support: Address family not supported by protocol
```