### PR TITLE
include jq for bash command line JSON parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         snmp-mibs-downloader                \
         unzip                               \
         python                              \
+        jq                                  \
                                                 && \
     apt-get clean && rm -Rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         git                                 \
         gperf                               \
         iputils-ping                        \
+        jq                                  \
         libapache2-mod-php                  \
         libcache-memcached-perl             \
         libcgi-pm-perl                      \
@@ -78,7 +79,6 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         snmp-mibs-downloader                \
         unzip                               \
         python                              \
-        jq                                  \
                                                 && \
     apt-get clean && rm -Rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
include jq for bash command line JSON parsing to allow for very simple bash shell script Nagios checks