### PR TITLE
chown for nagios files not working as expected

### DIFF
--- a/overlay/etc/sv/nagios/run
+++ b/overlay/etc/sv/nagios/run
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 echo "checking permissions for nagios & nagiosgraph"
-find /opt/nagios \! -user ${NAGIOS_USER} -exec chown ${NAGIOSUSER}:${NAGIOSUSER} '{}' +
-find /opt/nagiosgraph \! -user ${NAGIOS_USER} -exec chown ${NAGIOSUSER}:${NAGIOSUSER} '{}' +
+find /opt/nagios \! -user ${NAGIOS_USER} -exec chown ${NAGIOS_USER}:${NAGIOS_GROUP} '{}' +
+find /opt/nagiosgraph \! -user ${NAGIOS_USER} -exec chown ${NAGIOS_USER}:${NAGIOS_GROUP} '{}' +
 if ! [ -f /opt/nagiosgraph/etc/ngshared.pm ]; then
 echo "Configuring Nagiosgraph"
 


### PR DESCRIPTION
Environment variable NAGIOSUSER is not set in Dockerfile. Should rather use NAGIOS_USER and NAGIOS_GROUP for setting ownership in /opt/nagios and /opt/nagiosgraph