### PR TITLE
Fix check_ping to support ping ipv6 ip 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,8 +119,10 @@ RUN cd /tmp                                                                     
     git clone https://github.com/nagios-plugins/nagios-plugins.git -b $NAGIOS_PLUGINS_BRANCH  && \
     cd nagios-plugins                                                                         && \
     ./tools/setup                                                                             && \
-    ./configure                  \
-        --prefix=${NAGIOS_HOME}  \
+    ./configure                                                 \
+        --prefix=${NAGIOS_HOME}                                 \
+        --with-ipv6                                             \
+        --with-ping6-command="/bin/ping6 -n -U -W %d -c %d %s"  \
                                                                                               && \
     make                                                                                      && \
     make install                                                                              && \


### PR DESCRIPTION
ping6 command not detected when docker image build via Docker Hub

**Actual behavior**

```
docker run --name nagios4_ipv6  jasonrivers/nagios:latest
docker exec -it nagios4_ipv6  /opt/nagios/libexec/check_ping  -H ipv6.google.com  -w 300.0,20% -c 300.0,20%
CRITICAL - Host not found (ipv6.google.com)
```

**Expected behavior**

```
docker run --name nagios4_ipv6  jasonrivers/nagios:latest
docker exec -it nagios4_ipv6  /opt/nagios/libexec/check_ping  -H ipv6.google.com  -w 300.0,20% -c 300.0,20%
PING OK - Packet loss = 0%, RTA = 8.85 ms|rta=8.854000ms;300.000000;300.000000;0.000000 pl=0%;20;20;0
```
