### PR TITLE
Add plugins check-mqtt and check_sql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
-sudo:
-  - required
-language:
-  - bash
-services:
-  - docker
-
-install:
-  - git clone https://github.com/JasonRivers/Docker-Nagios.git ~/Docker-Nagios
+language: minimal
 
 script:
-  - ./build.sh
+  - docker-compose build
 
+before_deploy:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+deploy:
+  - provider: script
+    script: docker push janniswarnat/nagios:latest
+    on:
+      branch: master
+  - provider: script
+    script: docker tag janniswarnat/nagios janniswarnat/nagios:snapshot &&
+      docker push janniswarnat/nagios:snapshot
+    on:
+      branch: dev
+  - provider: script
+    script: docker tag janniswarnat/nagios janniswarnat/nagios:${TRAVIS_TAG} &&
+      docker push janniswarnat/nagios:${TRAVIS_TAG}
+    on:
+      tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         php-gd                              \
         postfix                             \
         python-pip                          \
+        python3-pip                         \
         rsyslog                             \
         runit                               \
         smbclient                           \
@@ -159,8 +160,8 @@ RUN cd /tmp                                                          && \
     cp share/nagiosgraph.ssi ${NAGIOS_HOME}/share/ssi/common-header.ssi
 
 RUN cd /opt                                                                         && \
-    pip install jsonpath-rw                                                         && \
-    pip install paho-mqtt                                                           && \
+    pip3 install jsonpath-rw                                                         && \
+    pip3 install paho-mqtt                                                           && \
     pip install pymssql                                                             && \
     git clone https://github.com/willixix/naglio-plugins.git     WL-Nagios-Plugins  && \
     git clone https://github.com/JasonRivers/nagios-plugins.git  JR-Nagios-Plugins  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Jason Rivers <jason@jasonrivers.co.uk>
 ENV NAGIOS_HOME            /opt/nagios
 ENV NAGIOS_USER            nagios
 ENV NAGIOS_GROUP           nagios
+ARG DOCKER_GID=996
 ENV NAGIOS_CMDUSER         nagios
 ENV NAGIOS_CMDGROUP        nagios
 ENV NAGIOS_FQDN            nagios.example.com
@@ -177,6 +178,7 @@ RUN cd /opt                                                                     
     cp /opt/jpmens-mqtt/check-mqtt.py ${NAGIOS_HOME}/libexec/                       && \
     cp /opt/danfruehauf-sql/check_sql/check_sql ${NAGIOS_HOME}/libexec/
 
+RUN pip install docker-compose
 
 RUN sed -i.bak 's/.*\=www\-data//g' /etc/apache2/envvars
 RUN export DOC_ROOT="DocumentRoot $(echo $NAGIOS_HOME/share)"                         && \
@@ -249,3 +251,6 @@ EXPOSE 80
 VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc"
 
 CMD [ "/usr/local/bin/start_nagios" ]
+
+RUN groupadd -g ${DOCKER_GID} docker
+RUN usermod -aG docker ${NAGIOS_USER}

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         libcache-memcached-perl             \
         libcgi-pm-perl                      \
         libdbd-mysql-perl                   \
+        libdbd-pg-perl                      \
         libdbi-dev                          \
         libdbi-perl                         \
         libfreeradius-client-dev            \
@@ -157,16 +158,24 @@ RUN cd /tmp                                                          && \
     cp share/nagiosgraph.ssi ${NAGIOS_HOME}/share/ssi/common-header.ssi
 
 RUN cd /opt                                                                         && \
+    pip install jsonpath-rw                                                         && \
+    pip install paho-mqtt                                                           && \
     pip install pymssql                                                             && \
     git clone https://github.com/willixix/naglio-plugins.git     WL-Nagios-Plugins  && \
     git clone https://github.com/JasonRivers/nagios-plugins.git  JR-Nagios-Plugins  && \
     git clone https://github.com/justintime/nagios-plugins.git   JE-Nagios-Plugins  && \
     git clone https://github.com/nagiosenterprises/check_mssql_collection.git   nagios-mssql  && \
+    git clone https://github.com/jpmens/check-mqtt.git           jpmens-mqtt        && \
+    git clone https://github.com/danfruehauf/nagios-plugins.git  danfruehauf-sql    && \
     chmod +x /opt/WL-Nagios-Plugins/check*                                          && \
     chmod +x /opt/JE-Nagios-Plugins/check_mem/check_mem.pl                          && \
-    cp /opt/JE-Nagios-Plugins/check_mem/check_mem.pl ${NAGIOS_HOME}/libexec/           && \
-    cp /opt/nagios-mssql/check_mssql_database.py ${NAGIOS_HOME}/libexec/                         && \
-    cp /opt/nagios-mssql/check_mssql_server.py ${NAGIOS_HOME}/libexec/
+    chmod +x /opt/jpmens-mqtt/check-mqtt.py                                         && \
+    chmod +x /opt/danfruehauf-sql/check_sql/check_sql                               && \
+    cp /opt/JE-Nagios-Plugins/check_mem/check_mem.pl ${NAGIOS_HOME}/libexec/        && \
+    cp /opt/nagios-mssql/check_mssql_database.py ${NAGIOS_HOME}/libexec/            && \
+    cp /opt/nagios-mssql/check_mssql_server.py ${NAGIOS_HOME}/libexec/              && \
+    cp /opt/jpmens-mqtt/check-mqtt.py ${NAGIOS_HOME}/libexec/                       && \
+    cp /opt/danfruehauf-sql/check_sql/check_sql ${NAGIOS_HOME}/libexec/
 
 
 RUN sed -i.bak 's/.*\=www\-data//g' /etc/apache2/envvars

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,7 @@
----
+version: '2.3'
 
-# This compose file acts as an example on using docker volumes for nagios
-# configuration. As nagios configurations are different for each site they are
-# not concidered part of the container image. The best way to deal with the
-# configurations is to store them in a volume allowing the user to upgrade the
-# image without the need to extract the site configuration from the container.
-
-version: '3'
 services:
   nagios:
-    image: jasonrivers/nagios:latest
-    volumes:
-    - nagiosetc:/opt/nagios/etc
-    - nagiosvar:/opt/nagios/var
-    - customplugins:/opt/Custom-Nagios-Plugins
-    - nagiosgraphvar:/opt/nagiosgraph/var
-    - nagiosgraphetc:/opt/nagiosgraph/etc
-
-volumes:
-    nagiosetc:
-    nagiosvar:
-    customplugins:
-    nagiosgraphvar:
-    nagiosgraphetc:
+    build:
+      context: .
+    image: janniswarnat/nagios


### PR DESCRIPTION
Hi all,

I found the Nagios plugins check-mqtt (https://github.com/jpmens/check-mqtt) and check_sql (https://github.com/danfruehauf/nagios-plugins/tree/master/check_sql) extremely useful. The former can check an MQTT broker for certain incoming message, for example. The latter is a generic plugin for the monitoring of SQL databases. I personally used it to query a Postgres database.

I added these two to the Dockerfile as well as the necessary Perl and Python packages.

Best regards

Jannis