### PR TITLE
Add NSCA support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         libwww-perl                         \
         m4                                  \
         netcat                              \
+        nsca                                \
         parallel                            \
         php-cli                             \
         php-gd                              \
@@ -219,14 +220,17 @@ RUN a2enmod session         && \
 RUN chmod +x /usr/local/bin/start_nagios        && \
     chmod +x /etc/sv/apache/run                 && \
     chmod +x /etc/sv/nagios/run                 && \
-    chmod +x /etc/sv/postfix/run                 && \
-    chmod +x /etc/sv/rsyslog/run                 && \
+    chmod +x /etc/sv/postfix/run                && \
+    chmod +x /etc/sv/rsyslog/run                && \
+    chmod +x /etc/sv/nsca/run                   && \
     chmod +x /opt/nagiosgraph/etc/fix-nagiosgraph-multiple-selection.sh
 
 RUN cd /opt/nagiosgraph/etc && \
     sh fix-nagiosgraph-multiple-selection.sh
 
 RUN rm /opt/nagiosgraph/etc/fix-nagiosgraph-multiple-selection.sh
+
+RUN mv /etc/nsca.cfg /etc/nsca.cfg.default
 
 # enable all runit services
 RUN ln -s /etc/sv/* /etc/service
@@ -242,6 +246,6 @@ RUN echo "ServerName ${NAGIOS_FQDN}" > /etc/apache2/conf-available/servername.co
 
 EXPOSE 80
 
-VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc"
+VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc" "/etc/nsca.cfg"
 
 CMD [ "/usr/local/bin/start_nagios" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -230,7 +230,7 @@ RUN cd /opt/nagiosgraph/etc && \
 
 RUN rm /opt/nagiosgraph/etc/fix-nagiosgraph-multiple-selection.sh
 
-RUN mv /etc/nsca.cfg /etc/nsca.cfg.default
+RUN mkdir /opt/nsca && mv /etc/nsca.cfg /opt/nsca/nsca.cfg.default
 
 # enable all runit services
 RUN ln -s /etc/sv/* /etc/service
@@ -246,6 +246,6 @@ RUN echo "ServerName ${NAGIOS_FQDN}" > /etc/apache2/conf-available/servername.co
 
 EXPOSE 80
 
-VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc" "/etc/nsca.cfg"
+VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc" "/opt/nsca/nsca.cfg"
 
 CMD [ "/usr/local/bin/start_nagios" ]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ There are a number of environment variables that you can use to adjust the behav
 
 For best results your Nagios image should have access to both IPv4 & IPv6 networks 
 
+For NSCA support mount a volume with the configuration file and expose the nsca port (default 5667) as follows:
+
+```sh
+docker run --name nagios4 -p 0.0.0.0:8080:80 -p 0.0.0.0:5667:5667 -v /path-to-custom-nsca.cfg:/etc/nsca.cfg jasonrivers/nagios:latest
+```
+
 #### Credentials
 
 The default credentials for the web interface is `nagiosadmin` / `nagios`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For best results your Nagios image should have access to both IPv4 & IPv6 networ
 For NSCA support mount a volume with the configuration file and expose the nsca port (default 5667) as follows:
 
 ```sh
-docker run --name nagios4 -p 0.0.0.0:8080:80 -p 0.0.0.0:5667:5667 -v /path-to-custom-nsca.cfg:/etc/nsca.cfg jasonrivers/nagios:latest
+docker run --name nagios4 -p 0.0.0.0:8080:80 -p 0.0.0.0:5667:5667 -v /path-to-custom-nsca.cfg:/opt/nsca/nsca.cfg jasonrivers/nagios:latest
 ```
 
 #### Credentials

--- a/overlay/etc/sv/nsca/run
+++ b/overlay/etc/sv/nsca/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -f "/etc/nsca.cfg" ]; then 
+    exec /usr/sbin/nsca -c /etc/nsca.cfg -f
+fi

--- a/overlay/etc/sv/nsca/run
+++ b/overlay/etc/sv/nsca/run
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-if [ -f "/etc/nsca.cfg" ]; then 
-    exec /usr/sbin/nsca -c /etc/nsca.cfg -f
+if [ -f "/opt/nsca/nsca.cfg" ]; then
+    exec /usr/sbin/nsca -c /opt/nsca/nsca.cfg -f
 fi

--- a/overlay/etc/sv/nsca/run
+++ b/overlay/etc/sv/nsca/run
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 if [ -f "/opt/nsca/nsca.cfg" ]; then
+    sleep 10
     exec /usr/sbin/nsca -c /opt/nsca/nsca.cfg -f
 fi


### PR DESCRIPTION
To solve issue #83 and #55 I added NSCA support to the container.
If the configuration file for nsca is not specified there no impact, so people with a running setup can transparently update to this version of the container.