### PR TITLE
remove nagiosgraph mount from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ docker run --name nagios4  \
   -v /path-to-nagios/var:/opt/nagios/var/ \
   -v /path-to-custom-plugins:/opt/Custom-Nagios-Plugins \
   -v /path-to-nagiosgraph-var:/opt/nagiosgraph/var \
-  -v /path-to-nagiosgraph-etc:/opt/nagiosgraph/etc \
   -p 0.0.0.0:8080:80 jasonrivers/nagios:latest
 ```
 


### PR DESCRIPTION
I fell over this issue today and suggest the readme be updated. Recommending the volume mount for nagiosgraph-etc was added in [PR 64](https://github.com/JasonRivers/Docker-Nagios/pull/64/files).
`/opt/nagiosgraph/etc` contains the following files by default. 
```
access.conf     labels.conf               nagiosgraph-nagios.cfg  nagiosgraph_fr.conf
datasetdb.conf  map                       nagiosgraph.conf        ngshared.pm
groupdb.conf    nagiosgraph-apache.conf   nagiosgraph_de.conf     rrdopts.conf
hostdb.conf     nagiosgraph-commands.cfg  nagiosgraph_es.conf     servdb.conf
```
Mounting an empty volume at that location hides these files. I would suggest that new users do not want that to happen and experienced users will be able to copy those files out before mounting a volume over it.