### PR TITLE
Update to Nagios 4.5.2 and related versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.1
-ENV NAGIOS_PLUGINS_BRANCH  2.4.8
+ENV NAGIOS_BRANCH          nagios-4.5.2
+ENV NAGIOS_PLUGINS_BRANCH  release-2.4.10
 ENV NRPE_BRANCH            nrpe-4.1.0
-ENV NCPA_BRANCH            v3.0.1
+ENV NCPA_BRANCH            v3.0.2
 ENV NSCA_BRANCH            nsca-2.10.2
 ENV NAGIOSTV_VERSION       0.8.7
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.0
+ENV NAGIOS_BRANCH          nagios-4.5.1
 ENV NAGIOS_PLUGINS_BRANCH  2.4.8
 ENV NRPE_BRANCH            nrpe-4.1.0
 ENV NCPA_BRANCH            v3.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
 ENV NAGIOS_BRANCH          nagios-4.5.0
-ENV NAGIOS_PLUGINS_BRANCH  release-2.4.7
+ENV NAGIOS_PLUGINS_BRANCH  2.4.8
 ENV NRPE_BRANCH            nrpe-4.1.0
-ENV NCPA_BRANCH            v2.4.1
+ENV NCPA_BRANCH            v3.0.1
 ENV NSCA_BRANCH            nsca-2.10.2
 ENV NAGIOSTV_VERSION       0.8.7
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Docker image for Nagios
 
 Build Status: [![Build Status](https://travis-ci.org/JasonRivers/Docker-Nagios.svg?branch=master)](https://travis-ci.org/JasonRivers/Docker-Nagios)
 
-Nagios Core 4.5.0 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
+Nagios Core 4.5.1 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
 
 | Product | Version |
 | ------- | ------- |
-| Nagios Core | 4.5.0 |
+| Nagios Core | 4.5.1 |
 | Nagios Plugins | 2.4.8 |
 | NRPE | 4.1.0 |
 | NCPA | 3.0.1 |

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Docker image for Nagios
 
 Build Status: [![Build Status](https://travis-ci.org/JasonRivers/Docker-Nagios.svg?branch=master)](https://travis-ci.org/JasonRivers/Docker-Nagios)
 
-Nagios Core 4.4.14 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
+Nagios Core 4.5.0 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
 
 | Product | Version |
 | ------- | ------- |
 | Nagios Core | 4.5.0 |
-| Nagios Plugins | 2.4.7 |
+| Nagios Plugins | 2.4.8 |
 | NRPE | 4.1.0 |
-| NCPA | 2.4.1 |
+| NCPA | 3.0.1 |
 | NSCA | 2.10.2 |
 
 ### Configurations

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Docker image for Nagios
 
 Build Status: [![Build Status](https://travis-ci.org/JasonRivers/Docker-Nagios.svg?branch=master)](https://travis-ci.org/JasonRivers/Docker-Nagios)
 
-Nagios Core 4.5.1 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
+Nagios Core 4.5.2 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
 
 | Product | Version |
 | ------- | ------- |
-| Nagios Core | 4.5.1 |
-| Nagios Plugins | 2.4.8 |
+| Nagios Core | 4.5.2 |
+| Nagios Plugins | 2.4.10 |
 | NRPE | 4.1.0 |
-| NCPA | 3.0.1 |
+| NCPA | 3.0.2 |
 | NSCA | 2.10.2 |
 
 ### Configurations


### PR DESCRIPTION
Nagios Code 4.4.14 -> 4.5.2
Nagios Plugins 2.4.6 -> 2.4.10
NCPA 2.4.1 -> 3.0.2

Supersedes (because it contains) #157.