### PR TITLE
Migrate Slack notifications to pg-actions reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "docker" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -62,9 +62,9 @@ jobs:
     - name: Upload SBoM to Dependency Track
       uses: DependencyTrack/gh-upload-sbom@v3.1.0
       with:
-        serverhostname: 'dtrack.int.pgmac.net'
+        serverHostname: 'dtrack.int.pgmac.net'
         protocol: 'https'
-        apikey: ${{ secrets.DT_APIKEY }}
+        apiKey: ${{ secrets.DT_APIKEY }}
         project: ${{ secrets.DT_PROJECT_UUID }}
-        bomfilename: 'syft-sbom.json'
-        autocreate: false
+        bomFilename: 'syft-sbom.json'
+        autoCreate: false

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -65,6 +65,7 @@ jobs:
         serverHostname: 'dtrack.int.pgmac.net'
         protocol: 'https'
         apiKey: ${{ secrets.DT_APIKEY }}
-        project: ${{ secrets.DT_PROJECT_UUID }}
+        projectName: Docker-Nagios
+        projectVersion: 0.0.7
         bomFilename: 'syft-sbom.json'
-        autoCreate: false
+        autoCreate: true

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -19,6 +19,8 @@ on:
     workflows: [ "Build my Nagios image and push to my registry" ]
     types: [ completed ]
   push:
+    branches:
+      - master
     tags:
       - "*.*.*"
 
@@ -34,7 +36,7 @@ jobs:
     - name: Scan the image and upload dependency results
       uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
       with:
-        image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+        image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || 0.0.7 }}
         format: cyclonedx-json
         output-file: syft-sbom.json
         artifact-name: syft-sbom.json
@@ -67,6 +69,6 @@ jobs:
         protocol: 'https'
         apiKey: ${{ secrets.DT_APIKEY }}
         projectName: Docker-Nagios
-        projectVersion: ${{ inputs.tags || steps.vars.outputs.tag }}
+        projectVersion: ${{ inputs.tags || 0.0.7 }}
         bomFilename: 'syft-sbom.json'
         autoCreate: true

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -1,0 +1,70 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow checks out code, builds an image, performs a container image
+# scan with Anchore's Syft tool, and uploads the results to the GitHub Dependency
+# submission API.
+
+# For more information on the Anchore sbom-action usage
+# and parameters, see https://github.com/anchore/sbom-action. For more
+# information about the Anchore SBOM tool, Syft, see
+# https://github.com/anchore/syft
+name: Anchore Syft SBOM scan
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [ "Build my Nagios image and push to my registry" ]
+    types: [ completed ]
+  push:
+    branches: [ "master" ]
+
+jobs:
+  Anchore-Build-Scan:
+    permissions:
+      contents: write # required to upload to the Dependency submission API
+      id-token: write
+      attestations: write
+      actions: read
+    runs-on: self-hosted
+    steps:
+    - name: Scan the image and upload dependency results
+      uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
+      with:
+        image: macro.int.pgmac.net:5000/nagios:0.0.7  # Start hardcoded - figure out inputs later
+        format: cyclonedx-json
+        output-file: syft-sbom.json
+        artifact-name: syft-sbom.json
+        dependency-snapshot: true
+
+    - name: Upload SBoM to GitHub Artifact storage
+      uses: actions/upload-artifact@v4
+      with:
+        name: syft-sbom.json
+        path: 'syft-sbom.json'
+        retention-days: 2
+        overwrite: true
+
+    - name: SHA256 hash the SBoM
+      id: sha256
+      run: echo "SHA256=$(sha256sum syft-sbom.json | cut -d ' ' -f1)" >> $GITHUB_ENV
+
+    - name: Attest the SBoM
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: macro.int.pgmac.net:5000/Docker-Nagios/syft-sbom.json
+        subject-digest: sha256:${{ env.SHA256 }}
+        show-summary: true
+        push-to-registry: true
+
+    - name: Upload SBoM to Dependency Track
+      uses: DependencyTrack/gh-upload-sbom@v3.1.0
+      with:
+        serverhostname: 'dtrack.int.pgmac.net'
+        protocol: 'https'
+        apikey: ${{ secrets.DT_APIKEY }}
+        project: ${{ secrets.DT_PROJECT_UUID }}
+        bomfilename: 'syft-sbom.json'
+        autocreate: false

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -57,7 +57,7 @@ jobs:
         subject-name: macro.int.pgmac.net:5000/Docker-Nagios/syft-sbom.json
         subject-digest: sha256:${{ env.SHA256 }}
         show-summary: true
-        push-to-registry: true
+        push-to-registry: false
 
     - name: Upload SBoM to Dependency Track
       uses: DependencyTrack/gh-upload-sbom@v3.1.0

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -43,15 +43,8 @@ jobs:
         format: cyclonedx-json
         output-file: syft-sbom.json
         artifact-name: syft-sbom.json
+        upload-artifact: true
         dependency-snapshot: true
-
-    - name: Upload SBoM to GitHub Artifact storage
-      uses: actions/upload-artifact@v4
-      with:
-        name: syft-sbom.json
-        path: 'syft-sbom.json'
-        retention-days: 2
-        overwrite: true
 
     - name: SHA256 hash the SBoM
       id: sha256

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -38,7 +38,8 @@ jobs:
     - name: Scan the image and upload dependency results
       uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
       with:
-        image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+        #image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+        path: ./
         format: cyclonedx-json
         output-file: syft-sbom.json
         artifact-name: syft-sbom.json

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -33,10 +33,14 @@ jobs:
       actions: read
     runs-on: self-hosted
     steps:
+    - name: Set the image version
+      id: vars
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
     - name: Scan the image and upload dependency results
       uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
       with:
-        image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || 0.0.7 }}
+        image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
         format: cyclonedx-json
         output-file: syft-sbom.json
         artifact-name: syft-sbom.json
@@ -69,6 +73,6 @@ jobs:
         protocol: 'https'
         apiKey: ${{ secrets.DT_APIKEY }}
         projectName: Docker-Nagios
-        projectVersion: ${{ inputs.tags || 0.0.7 }}
+        projectVersion: ${{ inputs.tags || steps.vars.outputs.tag }}
         bomFilename: 'syft-sbom.json'
         autoCreate: true

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -19,7 +19,8 @@ on:
     workflows: [ "Build my Nagios image and push to my registry" ]
     types: [ completed ]
   push:
-    branches: [ "master" ]
+    tags:
+      - "*.*.*"
 
 jobs:
   Anchore-Build-Scan:
@@ -33,7 +34,7 @@ jobs:
     - name: Scan the image and upload dependency results
       uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
       with:
-        image: macro.int.pgmac.net:5000/nagios:0.0.7  # Start hardcoded - figure out inputs later
+        image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
         format: cyclonedx-json
         output-file: syft-sbom.json
         artifact-name: syft-sbom.json
@@ -66,6 +67,6 @@ jobs:
         protocol: 'https'
         apiKey: ${{ secrets.DT_APIKEY }}
         projectName: Docker-Nagios
-        projectVersion: 0.0.7
+        projectVersion: ${{ inputs.tags || steps.vars.outputs.tag }}
         bomFilename: 'syft-sbom.json'
         autoCreate: true

--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -18,11 +18,9 @@ on:
   workflow_run:
     workflows: [ "Build my Nagios image and push to my registry" ]
     types: [ completed ]
-  push:
-    branches:
-      - master
-    tags:
-      - "*.*.*"
+  # push:
+  #   tags:
+  #     - "*.*.*"
 
 jobs:
   Anchore-Build-Scan:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
     - name: Push to my internal registry
-      if: github.ref == 'refs/heads/"main"'
+      if: github.ref == 'refs/heads/"master"'
       run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
     - name: Exit code failure
       if: failure()

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,6 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
     - name: Push to my internal registry
-      if: github.ref == 'refs/heads/"master"'
       run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
     - name: Exit code failure
       if: failure()

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,69 @@
+name: Build my Nagaios image and push to my registry
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+  workflow_dispatch:
+jobs:
+  build-n-push:
+    runs-on: self-hosted
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set the image version
+      id: vars
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+    - name: Push to my internal registry
+      if: github.ref == 'refs/heads/"main"'
+      run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+    - name: Exit code failure
+      if: failure()
+      run: |
+        echo "colour=danger" >> $GITHUB_ENV
+        echo "icon=🛑" >> $GITHUB_ENV
+    - name: Exit code cancelled
+      if: cancelled()
+      run: |
+        echo "colour=warning" >> $GITHUB_ENV
+        echo "icon=⚠" >> $GITHUB_ENV
+    - name: Exit code success
+      if: success()
+      run: |
+        echo "colour=good" >> $GITHUB_ENV
+        echo "icon=✅" >> $GITHUB_ENV
+
+    - name: Send Slack message
+      uses: slackapi/slack-github-action@v1.23.0
+      with:
+        payload: |
+          {
+            "channel": "builds",
+            "attachments": [
+              {
+                "mrkdwn_in": ["text", "pretext"],
+                "fallback": ${{ toJSON(join(github.event.commits.*.message, '<br>') || ':point_right: Manually triggered') }},
+                "color": "${{ env.colour || 'grey' }}",
+                "pretext": "${{ env.icon || '?' }} ${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}",
+                "author_name": "${{ github.triggering_actor || github.actor }}",
+                "title": "${{ github.workflow }}",
+                "title_link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                "text": ${{ toJSON(join(github.event.commits.*.message, '\n') || ':point_right: Manually triggered') }}
+              },
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.event.pull_request.html_url || github.event.head_commit.url || github.server_url }}|View commit>"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Build my Nagaios image and push to my registry
+name: Build my Nagios image and push to my registry
 
 on:
   push:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,11 @@ on:
   workflow_dispatch:
 jobs:
   build-n-push:
+    permissions:
+      id-token: write
+      attestations: write
+      actions: read
+      contents: write
     runs-on: self-hosted
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,6 +17,45 @@ jobs:
       run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
     - name: Push to my internal registry
       run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+
+    - name: Run Syft SBoM scan
+        uses: anchore/sbom-action@v0.17.8
+        with:
+          image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+          format: cyclonedx-json
+          output-file: syft-sbom.json
+          artifact-name: syft-sbom.json
+
+      - name: Upload SBoM to GitHub Artifact storage
+        uses: actions/upload-artifact@v4
+        with:
+            name: syft-sbom.json
+            path: 'syft-sbom.json'
+            retention-days: 2
+            overwrite: true
+
+      - name: SHA256 hash the SBoM
+        id: sha256
+        run: echo "SHA256=$(sha256sum syft-sbom.json | cut -d ' ' -f1)" >> $GITHUB_ENV
+
+      - name: Attest the SBoM
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: macro.int.pgmac.net:5000/Docker-Nagios/syft-sbom.json
+          subject-digest: sha256:${{ env.SHA256 }}
+          show-summary: true
+          push-to-registry: true
+
+      - name: Upload SBoM to Dependency Track
+        uses: DependencyTrack/gh-upload-sbom@v3.1.0
+        with:
+          serverhostname: 'dtrack.int.pgmac.net'
+          protocol: 'https'
+          apikey: ${{ secrets.DT_APIKEY }}
+          project: ${{ secrets.DT_PROJECT_UUID }}
+          bomfilename: 'syft-sbom.json'
+          autocreate: false
+
     - name: Exit code failure
       if: failure()
       run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,62 +10,67 @@ jobs:
     runs-on: self-hosted
     steps:
     - uses: actions/checkout@v3
+
     - name: Set the image version
       id: vars
       run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+
     - name: Push to my internal registry
       run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
 
     - name: Run Syft SBoM scan
-        uses: anchore/sbom-action@v0.17.8
-        with:
-          image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
-          format: cyclonedx-json
-          output-file: syft-sbom.json
-          artifact-name: syft-sbom.json
+      uses: anchore/sbom-action@v0.17.8
+      with:
+        image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+        format: cyclonedx-json
+        output-file: syft-sbom.json
+        artifact-name: syft-sbom.json
 
-      - name: Upload SBoM to GitHub Artifact storage
-        uses: actions/upload-artifact@v4
-        with:
-            name: syft-sbom.json
-            path: 'syft-sbom.json'
-            retention-days: 2
-            overwrite: true
+    - name: Upload SBoM to GitHub Artifact storage
+      uses: actions/upload-artifact@v4
+      with:
+        name: syft-sbom.json
+        path: 'syft-sbom.json'
+        retention-days: 2
+        overwrite: true
 
-      - name: SHA256 hash the SBoM
-        id: sha256
-        run: echo "SHA256=$(sha256sum syft-sbom.json | cut -d ' ' -f1)" >> $GITHUB_ENV
+    - name: SHA256 hash the SBoM
+      id: sha256
+      run: echo "SHA256=$(sha256sum syft-sbom.json | cut -d ' ' -f1)" >> $GITHUB_ENV
 
-      - name: Attest the SBoM
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: macro.int.pgmac.net:5000/Docker-Nagios/syft-sbom.json
-          subject-digest: sha256:${{ env.SHA256 }}
-          show-summary: true
-          push-to-registry: true
+    - name: Attest the SBoM
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: macro.int.pgmac.net:5000/Docker-Nagios/syft-sbom.json
+        subject-digest: sha256:${{ env.SHA256 }}
+        show-summary: true
+        push-to-registry: true
 
-      - name: Upload SBoM to Dependency Track
-        uses: DependencyTrack/gh-upload-sbom@v3.1.0
-        with:
-          serverhostname: 'dtrack.int.pgmac.net'
-          protocol: 'https'
-          apikey: ${{ secrets.DT_APIKEY }}
-          project: ${{ secrets.DT_PROJECT_UUID }}
-          bomfilename: 'syft-sbom.json'
-          autocreate: false
+    - name: Upload SBoM to Dependency Track
+      uses: DependencyTrack/gh-upload-sbom@v3.1.0
+      with:
+        serverhostname: 'dtrack.int.pgmac.net'
+        protocol: 'https'
+        apikey: ${{ secrets.DT_APIKEY }}
+        project: ${{ secrets.DT_PROJECT_UUID }}
+        bomfilename: 'syft-sbom.json'
+        autocreate: false
 
     - name: Exit code failure
       if: failure()
       run: |
         echo "colour=danger" >> $GITHUB_ENV
         echo "icon=🛑" >> $GITHUB_ENV
+
     - name: Exit code cancelled
       if: cancelled()
       run: |
         echo "colour=warning" >> $GITHUB_ENV
         echo "icon=⚠" >> $GITHUB_ENV
+
     - name: Exit code success
       if: success()
       run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,104 +14,104 @@ jobs:
       contents: write
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set the image version
-      id: vars
-      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      - name: Set the image version
+        id: vars
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
 
-    - name: Push to my internal registry
-      run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+      - name: Push to my internal registry
+        run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
 
-    - name: Run Syft SBoM scan
-      uses: anchore/sbom-action@v0.17.8
-      with:
-        image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
-        format: cyclonedx-json
-        output-file: syft-sbom.json
-        artifact-name: syft-sbom.json
+      - name: Run Syft SBoM scan
+        uses: anchore/sbom-action@v0.17.8
+        with:
+          image: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+          format: cyclonedx-json
+          output-file: syft-sbom.json
+          artifact-name: syft-sbom.json
 
-    - name: Upload SBoM to GitHub Artifact storage
-      uses: actions/upload-artifact@v4
-      with:
-        name: syft-sbom.json
-        path: 'syft-sbom.json'
-        retention-days: 2
-        overwrite: true
+      - name: Upload SBoM to GitHub Artifact storage
+        uses: actions/upload-artifact@v4
+        with:
+          name: syft-sbom.json
+          path: "syft-sbom.json"
+          retention-days: 2
+          overwrite: true
 
-    - name: SHA256 hash the SBoM
-      id: sha256
-      run: echo "SHA256=$(sha256sum syft-sbom.json | cut -d ' ' -f1)" >> $GITHUB_ENV
+      - name: SHA256 hash the SBoM
+        id: sha256
+        run: echo "SHA256=$(sha256sum syft-sbom.json | cut -d ' ' -f1)" >> $GITHUB_ENV
 
-    - name: Attest the SBoM
-      uses: actions/attest-build-provenance@v1
-      with:
-        subject-name: macro.int.pgmac.net:5000/Docker-Nagios/syft-sbom.json
-        subject-digest: sha256:${{ env.SHA256 }}
-        show-summary: true
-        push-to-registry: true
+      - name: Attest the SBoM
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: macro.int.pgmac.net:5000/Docker-Nagios/syft-sbom.json
+          subject-digest: sha256:${{ env.SHA256 }}
+          show-summary: true
+          push-to-registry: false
 
-    - name: Upload SBoM to Dependency Track
-      uses: DependencyTrack/gh-upload-sbom@v3.1.0
-      with:
-        serverhostname: 'dtrack.int.pgmac.net'
-        protocol: 'https'
-        apikey: ${{ secrets.DT_APIKEY }}
-        project: ${{ secrets.DT_PROJECT_UUID }}
-        bomfilename: 'syft-sbom.json'
-        autocreate: false
+      - name: Upload SBoM to Dependency Track
+        uses: DependencyTrack/gh-upload-sbom@v3.1.0
+        with:
+          serverhostname: "dtrack.int.pgmac.net"
+          protocol: "https"
+          apikey: ${{ secrets.DT_APIKEY }}
+          project: ${{ secrets.DT_PROJECT_UUID }}
+          bomfilename: "syft-sbom.json"
+          autocreate: false
 
-    - name: Exit code failure
-      if: failure()
-      run: |
-        echo "colour=danger" >> $GITHUB_ENV
-        echo "icon=🛑" >> $GITHUB_ENV
+      - name: Exit code failure
+        if: failure()
+        run: |
+          echo "colour=danger" >> $GITHUB_ENV
+          echo "icon=🛑" >> $GITHUB_ENV
 
-    - name: Exit code cancelled
-      if: cancelled()
-      run: |
-        echo "colour=warning" >> $GITHUB_ENV
-        echo "icon=⚠" >> $GITHUB_ENV
+      - name: Exit code cancelled
+        if: cancelled()
+        run: |
+          echo "colour=warning" >> $GITHUB_ENV
+          echo "icon=⚠" >> $GITHUB_ENV
 
-    - name: Exit code success
-      if: success()
-      run: |
-        echo "colour=good" >> $GITHUB_ENV
-        echo "icon=✅" >> $GITHUB_ENV
+      - name: Exit code success
+        if: success()
+        run: |
+          echo "colour=good" >> $GITHUB_ENV
+          echo "icon=✅" >> $GITHUB_ENV
 
-    - name: Send Slack message
-      uses: slackapi/slack-github-action@v1.23.0
-      with:
-        payload: |
-          {
-            "channel": "builds",
-            "attachments": [
-              {
-                "mrkdwn_in": ["text", "pretext"],
-                "fallback": ${{ toJSON(join(github.event.commits.*.message, '<br>') || ':point_right: Manually triggered') }},
-                "color": "${{ env.colour || 'grey' }}",
-                "pretext": "${{ env.icon || '?' }} ${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}",
-                "author_name": "${{ github.triggering_actor || github.actor }}",
-                "title": "${{ github.workflow }}",
-                "title_link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                "text": ${{ toJSON(join(github.event.commits.*.message, '\n') || ':point_right: Manually triggered') }}
-              },
-              {
-                "blocks": [
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "<${{ github.event.pull_request.html_url || github.event.head_commit.url || github.server_url }}|View commit>"
+      - name: Send Slack message
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "channel": "builds",
+              "attachments": [
+                {
+                  "mrkdwn_in": ["text", "pretext"],
+                  "fallback": ${{ toJSON(join(github.event.commits.*.message, '<br>') || ':point_right: Manually triggered') }},
+                  "color": "${{ env.colour || 'grey' }}",
+                  "pretext": "${{ env.icon || '?' }} ${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}",
+                  "author_name": "${{ github.triggering_actor || github.actor }}",
+                  "title": "${{ github.workflow }}",
+                  "title_link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                  "text": ${{ toJSON(join(github.event.commits.*.message, '\n') || ':point_right: Manually triggered') }}
+                },
+                {
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.event.pull_request.html_url || github.event.head_commit.url || github.server_url }}|View commit>"
+                      }
                     }
-                  }
-                ]
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,8 +5,14 @@ on:
     tags:
       - "*.*.*"
   workflow_dispatch:
+
 jobs:
+  slack-start:
+    uses: pgmac-net/pg-actions/.github/workflows/slack-notify-start.yml@main
+    secrets: inherit
+
   build-n-push:
+    needs: [slack-start]
     permissions:
       id-token: write
       attestations: write
@@ -71,54 +77,13 @@ jobs:
           bomfilename: "syft-sbom.json"
           autocreate: false
 
-      - name: Exit code failure
-        if: failure()
-        run: |
-          echo "colour=danger" >> $GITHUB_ENV
-          echo "icon=🛑" >> $GITHUB_ENV
-
-      - name: Exit code cancelled
-        if: cancelled()
-        run: |
-          echo "colour=warning" >> $GITHUB_ENV
-          echo "icon=⚠" >> $GITHUB_ENV
-
-      - name: Exit code success
-        if: success()
-        run: |
-          echo "colour=good" >> $GITHUB_ENV
-          echo "icon=✅" >> $GITHUB_ENV
-
-      - name: Send Slack message
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "channel": "builds",
-              "attachments": [
-                {
-                  "mrkdwn_in": ["text", "pretext"],
-                  "fallback": ${{ toJSON(join(github.event.commits.*.message, '<br>') || ':point_right: Manually triggered') }},
-                  "color": "${{ env.colour || 'grey' }}",
-                  "pretext": "${{ env.icon || '?' }} ${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}",
-                  "author_name": "${{ github.triggering_actor || github.actor }}",
-                  "title": "${{ github.workflow }}",
-                  "title_link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                  "text": ${{ toJSON(join(github.event.commits.*.message, '\n') || ':point_right: Manually triggered') }}
-                },
-                {
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "<${{ github.event.pull_request.html_url || github.event.head_commit.url || github.server_url }}|View commit>"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  slack-end:
+    if: always()
+    needs: [slack-start, build-n-push]
+    uses: pgmac-net/pg-actions/.github/workflows/slack-notify-end.yml@main
+    with:
+      ts: ${{ needs.slack-start.outputs.ts }}
+      start: ${{ needs.slack-start.outputs.start }}
+      startfmt: ${{ needs.slack-start.outputs.startfmt }}
+      status: ${{ needs.build-n-push.result }}
+    secrets: inherit

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,11 +20,18 @@ jobs:
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+      - name: Set up Docker Buildx (remote BuildKit)
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkitd.arc-runners.svc.cluster.local:1234
 
-      - name: Push to my internal registry
-        run: docker push macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: macro.int.pgmac.net:5000/nagios:${{ inputs.tags || steps.vars.outputs.tag }}
 
       - name: Run Syft SBoM scan
         uses: anchore/sbom-action@v0.17.8

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,164 @@
+name: SBOM Generator
+
+on:
+  push:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  sbom-build-attest:
+    runs-on: default
+    permissions:
+      id-token: write
+      attestations: write
+      actions: read
+      contents: write
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build the CycloneDX SBoM for this directory
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          format: cyclonedx-json
+          output-file: sbom.json
+          artifact-name: sbom.json
+          upload-artifact: true
+          dependency-snapshot: true
+
+      - name: Upload SBoM to Dependency Track
+        run: |
+          curl -kX "POST" "https://dtrack.int.pgmac.net/api/v1/bom" \
+          -H 'Content-Type: multipart/form-data' \
+          -H "X-Api-Key: ${{ secrets.DT_APIKEY }}" \
+          -F "autoCreate=true" \
+          -F "projectName=secscanrep" \
+          -F "projectVersion=1.0" \
+          -F "bom=@sbom.json"
+
+      - name: Build the SHA256 digest
+        id: sha256
+        run: |
+          echo "sha256=sha256:$(sha256sum sbom.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+
+      - name: Attest the SBoM
+        uses: actions/attest-build-provenance@v1
+        with:
+          #subject-path: sbom.json
+          subject-name: sbom.json
+          subject-digest: ${{ steps.sha256.outputs.sha256 }}
+          show-summary: true
+          push-to-registry: false
+
+      - name: Build the SPDX SBoM for this directory for later grype scans
+        uses: anchore/sbom-action@v0
+        id: spdx-scan
+        with:
+          path: ./
+          format: spdx-json
+          output-file: sbom-spdx.json
+          artifact-name: sbom-spdx.json
+          upload-artifact: true
+          dependency-snapshot: true
+
+      - name: Build the SHA256 digest
+        id: spdx-sha256
+        run: |
+          echo "sha256=sha256:$(sha256sum sbom-spdx.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+
+      - name: Attest the SBoM
+        uses: actions/attest-build-provenance@v1
+        with:
+          #subject-path: sbom.json
+          subject-name: sbom-spdx.json
+          subject-digest: ${{ steps.spdx-sha256.outputs.sha256 }}
+          show-summary: true
+          push-to-registry: false
+
+      - name: Scan the SPDX SBoM for vulnerabilities # The grype SBoM scan only scans SPDX format SBoMs
+        uses: anchore/scan-action@v3
+        id: scan
+        with:
+          sbom: sbom-spdx.json
+          fail-build: false # Reporting only mode for now - change to true to fail the build
+          #severity-cutoff: "medium" # Only fail the build if a vulnerability of this severity or higher is found
+          only-fixed: true # Only report vulnerabilities that have a fix available
+          output-format: sarif
+
+      - name: Upload SPDX SBoM scan SARIF report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+
+  sbom-verify:
+    runs-on: default
+    needs: [sbom-attest]
+    steps:
+      - name: Download a Build Artifact
+        uses: actions/download-artifact@v4.1.8
+        with:
+          # Name of the artifact to download. If unspecified, all artifacts for the run are downloaded.
+          #name: sbom.json
+          merge-multiple: false
+
+      - name: Verify the artefact attestation
+        run: gh attestation verify sbom.json/sbom.json -R ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  sbom-scan:
+    runs-on: default
+    needs: [sbom-attest]
+    steps:
+      - name: Download a Build Artifact
+        uses: actions/download-artifact@v4.1.8
+        with:
+          # Name of the artifact to download. If unspecified, all artifacts for the run are downloaded.
+          name: sbom-spdx.json
+          merge-multiple: false
+
+      - name: Verify the artefact attestation
+        run: gh attestation verify ./sbom-spdx.json -R ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Scan the SBoM
+        uses: anchore/scan-action@v3
+        with:
+          sbom: sbom-spdx.json
+          fail-build: false # Reporting only mode for now - change to true to fail the build
+          #severity-cutoff: "medium" # Only fail the build if a vulnerability of this severity or higher is found
+          only-fixed: true # Only report vulnerabilities that have a fix available
+          output-format: table
+          # output-file: results.sarif
+
+  sbom-attest-fail:
+    runs-on: default
+    permissions:
+      id-token: write
+      attestations: write
+      actions: read
+      contents: write
+      security-events: write
+    needs: [sbom-scan]
+    steps:
+      - name: Pull down the CycloneDX SBoM artefact
+        uses: actions/download-artifact@v4.1.8
+        with:
+          # Name of the artifact to download. If unspecified, all artifacts for the run are downloaded.
+          name: sbom.json
+          merge-multiple: false
+
+      - name: Modify the artefact
+        run: cat ./sbom.json | sed -e 's/CycloneDX/CBA-CycloneDX/g' > ./sbom.json
+
+      - name: Verify the artefact attestation
+        run: gh attestation verify ./sbom.json -R ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -136,29 +136,3 @@ jobs:
           only-fixed: true # Only report vulnerabilities that have a fix available
           output-format: table
           # output-file: results.sarif
-
-  sbom-attest-fail:
-    runs-on: default
-    permissions:
-      id-token: write
-      attestations: write
-      actions: read
-      contents: write
-      security-events: write
-    needs: [sbom-scan]
-    steps:
-      - name: Pull down the CycloneDX SBoM artefact
-        uses: actions/download-artifact@v4.1.8
-        with:
-          # Name of the artifact to download. If unspecified, all artifacts for the run are downloaded.
-          name: sbom.json
-          merge-multiple: false
-
-      - name: Modify the artefact
-        run: cat ./sbom.json | sed -e 's/CycloneDX/CBA-CycloneDX/g' > ./sbom.json
-
-      - name: Verify the artefact attestation
-        run: gh attestation verify ./sbom.json -R ${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -2,7 +2,7 @@ name: SBOM Generator
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
 
   workflow_dispatch:
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -97,7 +97,7 @@ jobs:
 
   sbom-verify:
     runs-on: default
-    needs: [sbom-attest]
+    needs: [sbom-build-attest]
     steps:
       - name: Download a Build Artifact
         uses: actions/download-artifact@v4.1.8
@@ -113,7 +113,7 @@ jobs:
 
   sbom-scan:
     runs-on: default
-    needs: [sbom-attest]
+    needs: [sbom-build-attest]
     steps:
       - name: Download a Build Artifact
         uses: actions/download-artifact@v4.1.8

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,7 +10,7 @@ permissions: read-all
 
 jobs:
   sbom-build-attest:
-    runs-on: default
+    runs-on: self-hosted
     permissions:
       id-token: write
       attestations: write
@@ -96,7 +96,7 @@ jobs:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
   sbom-verify:
-    runs-on: default
+    runs-on: self-hosted
     needs: [sbom-build-attest]
     steps:
       - name: Download a Build Artifact
@@ -112,7 +112,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   sbom-scan:
-    runs-on: default
+    runs-on: self-hosted
     needs: [sbom-build-attest]
     steps:
       - name: Download a Build Artifact

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,4 +1,4 @@
-name: SBOM Generator
+name: Build a bill of materials ... and scan it
 
 on:
   push:
@@ -6,121 +6,13 @@ on:
 
   workflow_dispatch:
 
-permissions: read-all
-
 jobs:
-  sbom-build-attest:
-    runs-on: self-hosted
+  sbom:
+    uses: pgmac-net/pg-actions/.github/workflows/sbom.yml@main
+    secrets: inherit
     permissions:
-      id-token: write
       attestations: write
-      actions: read
       contents: write
       security-events: write
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Build the CycloneDX SBoM for this directory
-        uses: anchore/sbom-action@v0
-        with:
-          path: ./
-          format: cyclonedx-json
-          output-file: sbom.json
-          artifact-name: sbom.json
-          upload-artifact: true
-          dependency-snapshot: true
-
-      - name: Upload SBoM to Dependency Track
-        run: |
-          curl -kX "POST" "https://dtrack.int.pgmac.net/api/v1/bom" \
-          -H 'Content-Type: multipart/form-data' \
-          -H "X-Api-Key: ${{ secrets.DT_APIKEY }}" \
-          -F "autoCreate=true" \
-          -F "projectName=${{ github.repository }}" \
-          -F "projectVersion=${{ github.sha }}" \
-          -F "bom=@sbom.json"
-
-      - name: Build the SHA256 digest
-        id: sha256
-        run: |
-          echo "sha256=sha256:$(sha256sum sbom.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-
-      - name: Attest the SBoM
-        if: github.event.repository.visibility == 'public'
-        uses: actions/attest-build-provenance@v1
-        with:
-          #subject-path: sbom.json
-          subject-name: sbom.json
-          subject-digest: ${{ steps.sha256.outputs.sha256 }}
-          show-summary: true
-          push-to-registry: false
-
-      - name: Build the SPDX SBoM for this directory for later grype scans
-        uses: anchore/sbom-action@v0
-        id: spdx-scan
-        with:
-          path: ./
-          format: spdx-json
-          output-file: sbom-spdx.json
-          artifact-name: sbom-spdx.json
-          upload-artifact: true
-          dependency-snapshot: true
-
-      - name: Build the SHA256 digest
-        id: spdx-sha256
-        run: |
-          echo "sha256=sha256:$(sha256sum sbom-spdx.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-
-      - name: Attest the SBoM
-        if: github.event.repository.visibility == 'public'
-        uses: actions/attest-build-provenance@v1
-        with:
-          #subject-path: sbom.json
-          subject-name: sbom-spdx.json
-          subject-digest: ${{ steps.spdx-sha256.outputs.sha256 }}
-          show-summary: true
-          push-to-registry: false
-
-      - name: Scan the SPDX SBoM for vulnerabilities # The grype SBoM scan only scans SPDX format SBoMs
-        uses: anchore/scan-action@v3
-        id: scan
-        with:
-          sbom: sbom-spdx.json
-          fail-build: false # Reporting only mode for now - change to true to fail the build
-          #severity-cutoff: "medium" # Only fail the build if a vulnerability of this severity or higher is found
-          only-fixed: true # Only report vulnerabilities that have a fix available
-          output-format: sarif
-
-      - name: Upload SPDX SBoM scan SARIF report
-        if: github.event.repository.visibility == 'public'
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
-
-  sbom-scan:
-    runs-on: self-hosted
-    needs: [sbom-build-attest]
-    steps:
-      - name: Download a Build Artifact
-        uses: actions/download-artifact@v4.1.8
-        with:
-          # Name of the artifact to download. If unspecified, all artifacts for the run are downloaded.
-          name: sbom-spdx.json
-          merge-multiple: false
-
-      - name: Verify the artefact attestation
-        if: github.event.repository.visibility == 'public'
-        run: gh attestation verify ./sbom-spdx.json -R ${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Scan the SBoM
-        uses: anchore/scan-action@v3
-        with:
-          sbom: sbom-spdx.json
-          fail-build: false # Reporting only mode for now - change to true to fail the build
-          #severity-cutoff: "medium" # Only fail the build if a vulnerability of this severity or higher is found
-          only-fixed: true # Only report vulnerabilities that have a fix available
-          output-format: table
-          # output-file: results.sarif
+      id-token: write
+      actions: read

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -37,8 +37,8 @@ jobs:
           -H 'Content-Type: multipart/form-data' \
           -H "X-Api-Key: ${{ secrets.DT_APIKEY }}" \
           -F "autoCreate=true" \
-          -F "projectName=secscanrep" \
-          -F "projectVersion=1.0" \
+          -F "projectName=${{ github.event.repository.name }}" \
+          -F "projectVersion=${{ github.sha }}" \
           -F "bom=@sbom.json"
 
       - name: Build the SHA256 digest
@@ -47,6 +47,7 @@ jobs:
           echo "sha256=sha256:$(sha256sum sbom.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
       - name: Attest the SBoM
+        if: github.event.repository.visibility == 'public'
         uses: actions/attest-build-provenance@v1
         with:
           #subject-path: sbom.json
@@ -72,6 +73,7 @@ jobs:
           echo "sha256=sha256:$(sha256sum sbom-spdx.json | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
       - name: Attest the SBoM
+        if: github.event.repository.visibility == 'public'
         uses: actions/attest-build-provenance@v1
         with:
           #subject-path: sbom.json
@@ -91,6 +93,7 @@ jobs:
           output-format: sarif
 
       - name: Upload SPDX SBoM scan SARIF report
+        if: github.event.repository.visibility == 'public'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
@@ -107,6 +110,7 @@ jobs:
           merge-multiple: false
 
       - name: Verify the artefact attestation
+        if: github.event.repository.visibility == 'public'
         run: gh attestation verify ./sbom-spdx.json -R ${{ github.repository }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -95,22 +95,6 @@ jobs:
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
-  sbom-verify:
-    runs-on: self-hosted
-    needs: [sbom-build-attest]
-    steps:
-      - name: Download a Build Artifact
-        uses: actions/download-artifact@v4.1.8
-        with:
-          # Name of the artifact to download. If unspecified, all artifacts for the run are downloaded.
-          #name: sbom.json
-          merge-multiple: false
-
-      - name: Verify the artefact attestation
-        run: gh attestation verify sbom.json/sbom.json -R ${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-
   sbom-scan:
     runs-on: self-hosted
     needs: [sbom-build-attest]

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -37,7 +37,7 @@ jobs:
           -H 'Content-Type: multipart/form-data' \
           -H "X-Api-Key: ${{ secrets.DT_APIKEY }}" \
           -F "autoCreate=true" \
-          -F "projectName=${{ github.event.repository.name }}" \
+          -F "projectName=${{ github.repository }}" \
           -F "projectVersion=${{ github.sha }}" \
           -F "bom=@sbom.json"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.4
+ENV NAGIOS_BRANCH          nagios-4.5.5
 ENV NAGIOS_PLUGINS_BRANCH  release-2.4.12
 ENV NRPE_BRANCH            nrpe-4.1.1
-ENV NCPA_BRANCH            v3.1.0
+ENV NCPA_BRANCH            v3.1.1
 ENV NSCA_BRANCH            nsca-2.10.3
 ENV NAGIOSTV_VERSION       0.9.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -243,6 +243,7 @@ RUN cd /tmp                                                                     
     make install                                                                           && \
     cd /tmp && rm -Rf mk_livestatus                                                        && \
     cd /tmp && rm -f mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz
+RUN echo "broker_module=/usr/local/lib/mk-livestatus/livestatus.o /usr/local/nagios/var/rw/live" >> ${NAGIOS_HOME}/etc/nagios.cfg
 
 # Installing nagvis
 RUN cd /opt  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         libjson-perl                        \
         libldap2-dev                        \
         libmonitoring-plugin-perl           \
-        libmysqlclient-dev                  \
+        libmariadb-dev                      \
         libnagios-object-perl               \
         libnet-snmp-perl                    \
         libnet-snmp-perl                    \
@@ -86,6 +86,8 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         php-php-gettext                     \
         php-sqlite3                         \
         postfix                             \
+        python3                             \
+        python3-venv                        \
         python3-paho-mqtt                   \
         python3-pip                         \
         python3-pymssql                     \
@@ -99,7 +101,6 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         snmp-mibs-downloader                \
         sqlite3                             \
         unzip                               \
-        python3                             \
                                                 && \
     apt-get clean && rm -Rf /var/lib/apt/lists/*
 
@@ -202,6 +203,7 @@ RUN cd /tmp                                                          && \
     cd /tmp && rm -Rf nagiosgraph
 
 RUN cd /opt                                                                         && \
+    pip install --break-system-packages pymssql paho-mqtt                           && \
     git clone https://github.com/willixix/naglio-plugins.git     WL-Nagios-Plugins  && \
     git clone https://github.com/JasonRivers/nagios-plugins.git  JR-Nagios-Plugins  && \
     git clone https://github.com/justintime/nagios-plugins.git   JE-Nagios-Plugins  && \
@@ -292,7 +294,7 @@ RUN cd /opt/nagiosgraph/etc && \
 RUN rm /opt/nagiosgraph/etc/fix-nagiosgraph-multiple-selection.sh
 
 # enable all runit services
-RUN ln -s /etc/sv/* /etc/service
+RUN ln -sf /etc/sv/* /etc/service
 
 # fix ping permissions for nagios user
 RUN chmod u+s /usr/bin/ping

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,11 +147,11 @@ RUN cd /tmp                                                                     
     git clone https://github.com/nagios-plugins/nagios-plugins.git -b $NAGIOS_PLUGINS_BRANCH  && \
     cd nagios-plugins                                                                         && \
     ./tools/setup                                                                             && \
-    ./configure                                                 \
-        --prefix=${NAGIOS_HOME}                                 \
-        --with-ipv6                                             \
-        --with-ping-command="/usr/bin/ping -n -U -W %d -c %d %s"  \
-        --with-ping6-command="/usr/bin/ping -6 -n -U -W %d -c %d %s"  \
+    ./configure                                                                                  \
+        --prefix=${NAGIOS_HOME}                                                                  \
+        --with-ipv6                                                                              \
+        --with-ping-command="/usr/bin/ping -n -U -W %d -c %d %s"                                 \
+        --with-ping6-command="/usr/bin/ping -6 -n -U -W %d -c %d %s"                             \
                                                                                               && \
     make                                                                                      && \
     make install                                                                              && \
@@ -246,23 +246,23 @@ RUN cd /tmp                                                                     
 RUN echo "broker_module=/usr/local/lib/mk-livestatus/livestatus.o /usr/local/nagios/var/rw/live" >> ${NAGIOS_HOME}/etc/nagios.cfg
 
 # Installing nagvis
-RUN cd /opt  && \
+RUN cd /opt                                                                                           && \
     git clone --depth 1 --branch nagvis-${NAGVIS_VERSION} https://github.com/NagVis/nagvis.git nagvis && \
-    cp nagvis/etc/nagvis.ini.php-sample nagvis/etc/nagvis.ini.php && \
-    cp nagvis/etc/apache2-nagvis.conf-sample /etc/apache2/conf-available/apache2-nagvis.conf && \
-    sed -ie 's%@NAGIOS_PATH@%/opt/nagios%g' /etc/apache2/conf-available/apache2-nagvis.conf && \
-    sed -ie 's%@NAGVIS_PATH@%/opt/nagvis/share%g' /etc/apache2/conf-available/apache2-nagvis.conf && \
-    sed -ie 's%@NAGVIS_WEB@%/nagvis%g' /etc/apache2/conf-available/apache2-nagvis.conf && \
-    sed -ie 's/#AuthName/AuthName/' /etc/apache2/conf-available/apache2-nagvis.conf && \
-    sed -ie 's/#AuthType/AuthType/' /etc/apache2/conf-available/apache2-nagvis.conf && \
-    sed -ie 's/#AuthUserFile/AuthUserFile/' /etc/apache2/conf-available/apache2-nagvis.conf && \
-    sed -ie 's/#Require/Require/' /etc/apache2/conf-available/apache2-nagvis.conf && \
-    mkdir -p /opt/nagvis/var/tmpl/compile/ && \
-    mkdir -p /opt/nagvis/var/tmpl/cache/ && \
-    a2enconf apache2-nagvis && \
-    chown -R ${NAGIOS_USER}:${NAGIOS_GROUP} /opt/nagvis/
-
-RUN mkdir -p /usr/local/nagios/var/rw                             && \
+    cp nagvis/etc/nagvis.ini.php-sample nagvis/etc/nagvis.ini.php                                     && \
+    sed -ie 's%^socket=.*$%socket="/usr/local/nagios/var/rw/live"%' nagvis/etc/nagvis.ini.php         && \
+    cp nagvis/etc/apache2-nagvis.conf-sample /etc/apache2/conf-available/apache2-nagvis.conf          && \
+    sed -ie 's%@NAGIOS_PATH@%/opt/nagios%g' /etc/apache2/conf-available/apache2-nagvis.conf           && \
+    sed -ie 's%@NAGVIS_PATH@%/opt/nagvis/share%g' /etc/apache2/conf-available/apache2-nagvis.conf     && \
+    sed -ie 's%@NAGVIS_WEB@%/nagvis%g' /etc/apache2/conf-available/apache2-nagvis.conf                && \
+    sed -ie 's/#AuthName/AuthName/' /etc/apache2/conf-available/apache2-nagvis.conf                   && \
+    sed -ie 's/#AuthType/AuthType/' /etc/apache2/conf-available/apache2-nagvis.conf                   && \
+    sed -ie 's/#AuthUserFile/AuthUserFile/' /etc/apache2/conf-available/apache2-nagvis.conf           && \
+    sed -ie 's/#Require/Require/' /etc/apache2/conf-available/apache2-nagvis.conf                     && \
+    mkdir -p /opt/nagvis/var/tmpl/compile/                                                            && \
+    mkdir -p /opt/nagvis/var/tmpl/cache/                                                              && \
+    a2enconf apache2-nagvis                                                                           && \
+    chown -R ${NAGIOS_USER}:${NAGIOS_GROUP} /opt/nagvis/                                              && \
+    mkdir -p /usr/local/nagios/var/rw                                                                 && \
     chown ${NAGIOS_USER}:${NAGIOS_GROUP} /usr/local/nagios/var/rw
 
 RUN sed -i.bak 's/.*\=www\-data//g' /etc/apache2/envvars
@@ -302,7 +302,7 @@ RUN mkdir -p /orig/var                            && \
     mkdir -p /orig/etc                            && \
     mkdir -p /orig/graph-etc                      && \
     mkdir -p /orig/graph-var                      && \
-    mkdir -p /orig/xinetd.d                && \
+    mkdir -p /orig/xinetd.d                       && \
     cp -Rp ${NAGIOS_HOME}/var/* /orig/var/        && \
     cp -Rp ${NAGIOS_HOME}/etc/* /orig/etc/        && \
     cp -Rp /opt/nagiosgraph/etc/* /orig/graph-etc && \
@@ -322,8 +322,8 @@ RUN a2enmod session         && \
 RUN chmod +x /usr/local/bin/start_nagios        && \
     chmod +x /etc/sv/apache/run                 && \
     chmod +x /etc/sv/nagios/run                 && \
-    chmod +x /etc/sv/postfix/run                 && \
-    chmod +x /etc/sv/rsyslog/run                 && \
+    chmod +x /etc/sv/postfix/run                && \
+    chmod +x /etc/sv/rsyslog/run                && \
     chmod +x /opt/nagiosgraph/etc/fix-nagiosgraph-multiple-selection.sh
 
 RUN cd /opt/nagiosgraph/etc && \
@@ -341,13 +341,13 @@ ENV APACHE_LOCK_DIR /var/run
 ENV APACHE_LOG_DIR /var/log/apache2
 
 #Set ServerName and timezone for Apache
-RUN echo "ServerName ${NAGIOS_FQDN}" > /etc/apache2/conf-available/servername.conf    && \
-    echo "PassEnv TZ" > /etc/apache2/conf-available/timezone.conf            && \
+RUN echo "ServerName ${NAGIOS_FQDN}" > /etc/apache2/conf-available/servername.conf                 && \
+    echo "PassEnv TZ" > /etc/apache2/conf-available/timezone.conf                                  && \
     ln -s /etc/apache2/conf-available/servername.conf /etc/apache2/conf-enabled/servername.conf    && \
     ln -s /etc/apache2/conf-available/timezone.conf /etc/apache2/conf-enabled/timezone.conf
 
 EXPOSE 80 5667 6557
 
-VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc"
+VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc" "/opt/nagvis/var" "/opt/nagvis/etc"
 
 CMD [ "/usr/local/bin/start_nagios" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.0
+ENV NAGIOS_BRANCH          nagios-4.5.2
 ENV NAGIOS_PLUGINS_BRANCH  release-2.4.7
 ENV NRPE_BRANCH            nrpe-4.1.0
 ENV NCPA_BRANCH            v2.4.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV NG_CGI_URL             /cgi-bin
 ENV NAGIOS_BRANCH          nagios-4.5.3
 ENV NAGIOS_PLUGINS_BRANCH  release-2.4.10
 ENV NRPE_BRANCH            nrpe-4.1.0
-ENV NCPA_BRANCH            v3.1.10
+ENV NCPA_BRANCH            v3.1.0
 ENV NSCA_BRANCH            nsca-2.10.2
 ENV NAGIOSTV_VERSION       0.9.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV NCPA_BRANCH            v3.1.2
 ENV NSCA_BRANCH            nsca-2.10.3
 ENV NAGIOSTV_VERSION       0.9.2
 ENV MK_LIVESTATUS_VERSION  1.5.0p23
+ENV NAGVIS_VERSION         1.9.44
 
 
 RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections  && \
@@ -242,6 +243,14 @@ RUN cd /tmp                                                                     
     make install                                                                           && \
     cd /tmp && rm -Rf mk_livestatus                                                        && \
     cd /tmp && rm -f mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz
+
+# Installing nagvis
+RUN cd /opt/nagios  && \
+    git clone --depth 1 --branch nagvis-${NAGVIS_VERSION} https://github.com/NagVis/nagvis.git nagvis && \
+    cp nagvis/etc/nagvis.ini.php-sample nagvis/etc/nagvis.ini.php && \
+    cp nagvis/etc/apache2-nagvis.conf-sample /etc/apache2/conf-available/apache2-nagvis.conf && \
+    a2enconf apache2-nagvis && \
+    chown ${NAGIOS_USER}:${NAGIOS_GROUP} /opt/nagios/nagvis/
 
 RUN mkdir -p /usr/local/nagios/var/rw                             && \
     chown ${NAGIOS_USER}:${NAGIOS_GROUP} /usr/local/nagios/var/rw

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.1
+ENV NAGIOS_BRANCH          nagios-4.5.2
 ENV NAGIOS_PLUGINS_BRANCH  release-2.4.8
 ENV NRPE_BRANCH            nrpe-4.1.0
 ENV NCPA_BRANCH            v3.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         libpq-dev                           \
         libradsec-dev                       \
         libredis-perl                       \
+        librrd-dev                          \
         librrds-perl                        \
         libssl-dev                          \
         libswitch-perl                      \
@@ -231,6 +232,7 @@ RUN cd /tmp && \
     tar xf nagiostv-${NAGIOSTV_VERSION}.tar.gz -C /opt/nagios/share/ && \
     rm /tmp/nagiostv-${NAGIOSTV_VERSION}.tar.gz
 
+RUN apt-get update && apt-get install -y libboost-all-dev
 RUN cd /tmp                                                                                && \
     wget https://macro.int.pgmac.net/mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz         && \
     tar zxf mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz                                  && \
@@ -238,7 +240,7 @@ RUN cd /tmp                                                                     
     ./configure --with-nagios4                                                             && \
     make                                                                                   && \
     make install                                                                           && \
-    cd /tmp && rm -Rf mk-livestatus-${MK_LIVESTATUS_VERSION}                               && \
+    cd /tmp && rm -Rf mk_livestatus                                                        && \
     cd /tmp && rm -f mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz
 
 RUN mkdir -p /usr/local/nagios/var/rw                             && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ ENV NRPE_BRANCH            nrpe-4.1.0
 ENV NCPA_BRANCH            v3.0.1
 ENV NSCA_BRANCH            nsca-2.10.2
 ENV NAGIOSTV_VERSION       0.8.7
-ENV NAGVIS_RELEASE         1.9.40
 
 
 RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections  && \
@@ -198,21 +197,6 @@ RUN cd /tmp                                                          && \
     cp share/nagiosgraph.ssi ${NAGIOS_HOME}/share/ssi/common-header.ssi && \
     cd /tmp && rm -Rf nagiosgraph
 
-RUN cd /tmp                                                          && \
-    wget http://www.nagvis.org/share/nagvis-${NAGVIS_RELEASE}.tar.gz && \
-    tar zxvf nagvis-${NAGVIS_RELEASE}.tar.gz                         && \
-    cd nagvis-${NAGVIS_RELEASE}                                      && \
-    ./install.sh -n ${NAGIOS_HOME}         \
-      -s Nagios                            \
-      -u ${NAGIOS_USER}                    \
-      -g ${NAGIOS_GROUP}                   \
-      -p /opt/nagvis                       \
-      -w /etc/apache2                      \
-      -a y -q                           && \
-    cd /tmp                             && \
-    rm -r /tmp/nagvis-${NAGVIS_RELEASE} && \
-    a2enconf nagvis
-
 RUN cd /opt                                                                         && \
     pip install pymssql paho-mqtt pymssql                                           && \
     git clone https://github.com/willixix/naglio-plugins.git     WL-Nagios-Plugins  && \
@@ -317,6 +301,6 @@ RUN echo "ServerName ${NAGIOS_FQDN}" > /etc/apache2/conf-available/servername.co
 
 EXPOSE 80 5667 
 
-VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc" "/opt/nagvis/var" "/opt/nagvis/etc"
+VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc"
 
 CMD [ "/usr/local/bin/start_nagios" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         snmp                                \
         snmpd                               \
         snmp-mibs-downloader                \
+        sqlite3                             \
         unzip                               \
         python3                             \
                                                 && \
@@ -201,16 +202,16 @@ RUN cd /tmp                                                          && \
     wget http://www.nagvis.org/share/nagvis-${NAGVIS_RELEASE}.tar.gz && \
     tar zxvf nagvis-${NAGVIS_RELEASE}.tar.gz                         && \
     cd nagvis-${NAGVIS_RELEASE}                                      && \
-    ./install.sh -n ${NAGIOS_HOME}      \
-      -s Nagios                         \
-      -u ${NAGIOS_USER}                 \
-      -g ${NAGIOS_GROUP}                \
-      -g ${NAGIOS_GROUP}                \
-      -p /opt/nagvis                    \
-      -w /etc/apache2                   \
-      -a y -q
-RUN cd / && rm -r /tmp/nagvis-${NAGVIS_RELEASE}
-RUN a2enconf nagvis
+    ./install.sh -n ${NAGIOS_HOME}         \
+      -s Nagios                            \
+      -u ${NAGIOS_USER}                    \
+      -g ${NAGIOS_GROUP}                   \
+      -p /opt/nagvis                       \
+      -w /etc/apache2                      \
+      -a y -q                           && \
+    cd /tmp                             && \
+    rm -r /tmp/nagvis-${NAGVIS_RELEASE} && \
+    a2enconf nagvis
 
 RUN cd /opt                                                                         && \
     pip install pymssql paho-mqtt pymssql                                           && \
@@ -316,6 +317,6 @@ RUN echo "ServerName ${NAGIOS_FQDN}" > /etc/apache2/conf-available/servername.co
 
 EXPOSE 80 5667 
 
-VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc"
+VOLUME "${NAGIOS_HOME}/var" "${NAGIOS_HOME}/etc" "/var/log/apache2" "/opt/Custom-Nagios-Plugins" "/opt/nagiosgraph/var" "/opt/nagiosgraph/etc" "/opt/nagvis/var" "/opt/nagvis/etc"
 
 CMD [ "/usr/local/bin/start_nagios" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:mantic-20240530
 MAINTAINER Jason Rivers <jason@jasonrivers.co.uk>
 
 ENV NAGIOS_HOME            /opt/nagios

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:mantic-20240530
+FROM ubuntu:24.04
 MAINTAINER Jason Rivers <jason@jasonrivers.co.uk>
 
 ENV NAGIOS_HOME            /opt/nagios

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.5
+ENV NAGIOS_BRANCH          nagios-4.5.6
 ENV NAGIOS_PLUGINS_BRANCH  release-2.4.12
 ENV NRPE_BRANCH            nrpe-4.1.1
 ENV NCPA_BRANCH            v3.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV NG_CGI_URL             /cgi-bin
 ENV NAGIOS_BRANCH          nagios-4.5.9
 ENV NAGIOS_PLUGINS_BRANCH  release-2.4.12
 ENV NRPE_BRANCH            nrpe-4.1.3
-ENV NCPA_BRANCH            v3.1.1
+ENV NCPA_BRANCH            v3.1.2
 ENV NSCA_BRANCH            nsca-2.10.3
 ENV NAGIOSTV_VERSION       0.9.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.6
+ENV NAGIOS_BRANCH          nagios-4.5.7
 ENV NAGIOS_PLUGINS_BRANCH  release-2.4.12
 ENV NRPE_BRANCH            nrpe-4.1.1
 ENV NCPA_BRANCH            v3.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ ENV NAGIOS_USER            nagios
 ENV NAGIOS_GROUP           nagios
 ENV NAGIOS_CMDUSER         nagios
 ENV NAGIOS_CMDGROUP        nagios
-ENV NAGIOS_FQDN            nagios.example.com
+ENV NAGIOS_FQDN            status.int.pgmac.net
 ENV NAGIOSADMIN_USER       nagiosadmin
 ENV NAGIOSADMIN_PASS       nagios
 ENV APACHE_RUN_USER        nagios
 ENV APACHE_RUN_GROUP       nagios
-ENV NAGIOS_TIMEZONE        UTC
+ENV NAGIOS_TIMEZONE        Australia/Brisbane
 ENV DEBIAN_FRONTEND        noninteractive
 ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
@@ -49,6 +49,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         libcgi-pm-perl                      \
         libcrypt-des-perl                   \
         libcrypt-rijndael-perl              \
+        libcrypt-x509-perl                  \
         libdbd-mysql-perl                   \
         libdbd-pg-perl                      \
         libdbi-dev                          \
@@ -72,6 +73,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         librrds-perl                        \
         libssl-dev                          \
         libswitch-perl                      \
+        libtext-glob-perl                   \
         libwww-perl                         \
         m4                                  \
         netcat                              \
@@ -257,10 +259,14 @@ RUN echo "use_timezone=${NAGIOS_TIMEZONE}" >> ${NAGIOS_HOME}/etc/nagios.cfg
 
 # Copy example config in-case the user has started with empty var or etc
 
-RUN mkdir -p /orig/var                     && \
-    mkdir -p /orig/etc                     && \
-    cp -Rp ${NAGIOS_HOME}/var/* /orig/var/ && \
-    cp -Rp ${NAGIOS_HOME}/etc/* /orig/etc/ 
+RUN mkdir -p /orig/var                            && \
+    mkdir -p /orig/etc                            && \
+    mkdir -p /orig/graph-etc                      && \
+    mkdir -p /orig/graph-var                      && \
+    cp -Rp ${NAGIOS_HOME}/var/* /orig/var/        && \
+    cp -Rp ${NAGIOS_HOME}/etc/* /orig/etc/        && \
+    cp -Rp /opt/nagiosgraph/etc/* /orig/graph-etc && \
+    cp -Rp /opt/nagiosgraph/var/* /orig/graph-var
 
 ## Set the permissions for example config
 RUN find /opt/nagios/etc \! -user ${NAGIOS_USER} -exec chown ${NAGIOS_USER}:${NAGIOS_GROUP} '{}' + && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.7
+ENV NAGIOS_BRANCH          nagios-4.5.9
 ENV NAGIOS_PLUGINS_BRANCH  release-2.4.12
-ENV NRPE_BRANCH            nrpe-4.1.1
+ENV NRPE_BRANCH            nrpe-4.1.3
 ENV NCPA_BRANCH            v3.1.1
 ENV NSCA_BRANCH            nsca-2.10.3
 ENV NAGIOSTV_VERSION       0.9.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,13 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.0
-ENV NAGIOS_PLUGINS_BRANCH  release-2.4.7
+ENV NAGIOS_BRANCH          nagios-4.5.1
+ENV NAGIOS_PLUGINS_BRANCH  release-2.4.8
 ENV NRPE_BRANCH            nrpe-4.1.0
-ENV NCPA_BRANCH            v2.4.1
+ENV NCPA_BRANCH            v3.0.1
 ENV NSCA_BRANCH            nsca-2.10.2
 ENV NAGIOSTV_VERSION       0.8.7
+ENV NAGVIS_RELEASE         1.9.40
 
 
 RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections  && \
@@ -41,6 +42,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         gettext                             \
         git                                 \
         gperf                               \
+        graphviz                            \
         iputils-ping                        \
         jq                                  \
         libapache2-mod-php                  \
@@ -77,6 +79,11 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         parallel                            \
         php-cli                             \
         php-gd                              \
+        php-json                            \
+        php-mbstring                        \
+        php-pdo                             \
+        php-php-gettext                     \
+        php-sqlite3                         \
         postfix                             \
         python3-pip                         \
         python3-nagiosplugin                \
@@ -189,6 +196,21 @@ RUN cd /tmp                                                          && \
                                                                      && \
     cp share/nagiosgraph.ssi ${NAGIOS_HOME}/share/ssi/common-header.ssi && \
     cd /tmp && rm -Rf nagiosgraph
+
+RUN cd /tmp                                                          && \
+    wget http://www.nagvis.org/share/nagvis-${NAGVIS_RELEASE}.tar.gz && \
+    tar zxvf nagvis-${NAGVIS_RELEASE}.tar.gz                         && \
+    cd nagvis-${NAGVIS_RELEASE}                                      && \
+    ./install.sh -n ${NAGIOS_HOME}      \
+      -s Nagios                         \
+      -u ${NAGIOS_USER}                 \
+      -g ${NAGIOS_GROUP}                \
+      -g ${NAGIOS_GROUP}                \
+      -p /opt/nagvis                    \
+      -w /etc/apache2                   \
+      -a y -q
+RUN cd / && rm -r /tmp/nagvis-${NAGVIS_RELEASE}
+RUN a2enconf nagvis
 
 RUN cd /opt                                                                         && \
     pip install pymssql paho-mqtt pymssql                                           && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         libtext-glob-perl                   \
         libwww-perl                         \
         m4                                  \
-        netcat                              \
+        netcat-openbsd                      \
         parallel                            \
         php-cli                             \
         php-gd                              \
@@ -86,7 +86,9 @@ RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set
         php-php-gettext                     \
         php-sqlite3                         \
         postfix                             \
+        python3-paho-mqtt                   \
         python3-pip                         \
+        python3-pymssql                     \
         python3-nagiosplugin                \
         rsync                               \
         rsyslog                             \
@@ -200,7 +202,6 @@ RUN cd /tmp                                                          && \
     cd /tmp && rm -Rf nagiosgraph
 
 RUN cd /opt                                                                         && \
-    pip install pymssql paho-mqtt pymssql                                           && \
     git clone https://github.com/willixix/naglio-plugins.git     WL-Nagios-Plugins  && \
     git clone https://github.com/JasonRivers/nagios-plugins.git  JR-Nagios-Plugins  && \
     git clone https://github.com/justintime/nagios-plugins.git   JE-Nagios-Plugins  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
 ENV NAGIOS_BRANCH          nagios-4.5.2
-ENV NAGIOS_PLUGINS_BRANCH  release-2.4.7
+ENV NAGIOS_PLUGINS_BRANCH  release-2.4.8
 ENV NRPE_BRANCH            nrpe-4.1.0
-ENV NCPA_BRANCH            v2.4.1
+ENV NCPA_BRANCH            v3.0.1
 ENV NSCA_BRANCH            nsca-2.10.2
 ENV NAGIOSTV_VERSION       0.8.7
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.3
-ENV NAGIOS_PLUGINS_BRANCH  release-2.4.10
-ENV NRPE_BRANCH            nrpe-4.1.0
+ENV NAGIOS_BRANCH          nagios-4.5.4
+ENV NAGIOS_PLUGINS_BRANCH  release-2.4.12
+ENV NRPE_BRANCH            nrpe-4.1.1
 ENV NCPA_BRANCH            v3.1.0
-ENV NSCA_BRANCH            nsca-2.10.2
+ENV NSCA_BRANCH            nsca-2.10.3
 ENV NAGIOSTV_VERSION       0.9.2
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -245,12 +245,21 @@ RUN cd /tmp                                                                     
     cd /tmp && rm -f mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz
 
 # Installing nagvis
-RUN cd /opt/nagios  && \
+RUN cd /opt  && \
     git clone --depth 1 --branch nagvis-${NAGVIS_VERSION} https://github.com/NagVis/nagvis.git nagvis && \
     cp nagvis/etc/nagvis.ini.php-sample nagvis/etc/nagvis.ini.php && \
     cp nagvis/etc/apache2-nagvis.conf-sample /etc/apache2/conf-available/apache2-nagvis.conf && \
+    sed -ie 's%@NAGIOS_PATH@%/opt/nagios%g' /etc/apache2/conf-available/apache2-nagvis.conf && \
+    sed -ie 's%@NAGVIS_PATH@%/opt/nagvis/share%g' /etc/apache2/conf-available/apache2-nagvis.conf && \
+    sed -ie 's%@NAGVIS_WEB@%/nagvis%g' /etc/apache2/conf-available/apache2-nagvis.conf && \
+    sed -ie 's/#AuthName/AuthName/' /etc/apache2/conf-available/apache2-nagvis.conf && \
+    sed -ie 's/#AuthType/AuthType/' /etc/apache2/conf-available/apache2-nagvis.conf && \
+    sed -ie 's/#AuthUserFile/AuthUserFile/' /etc/apache2/conf-available/apache2-nagvis.conf && \
+    sed -ie 's/#Require/Require/' /etc/apache2/conf-available/apache2-nagvis.conf && \
+    mkdir -p /opt/nagvis/var/tmpl/compile/ && \
+    mkdir -p /opt/nagvis/var/tmpl/cache/ && \
     a2enconf apache2-nagvis && \
-    chown ${NAGIOS_USER}:${NAGIOS_GROUP} /opt/nagios/nagvis/
+    chown -R ${NAGIOS_USER}:${NAGIOS_GROUP} /opt/nagvis/
 
 RUN mkdir -p /usr/local/nagios/var/rw                             && \
     chown ${NAGIOS_USER}:${NAGIOS_GROUP} /usr/local/nagios/var/rw

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,12 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.2
-ENV NAGIOS_PLUGINS_BRANCH  release-2.4.8
+ENV NAGIOS_BRANCH          nagios-4.5.3
+ENV NAGIOS_PLUGINS_BRANCH  release-2.4.10
 ENV NRPE_BRANCH            nrpe-4.1.0
-ENV NCPA_BRANCH            v3.0.1
+ENV NCPA_BRANCH            v3.1.10
 ENV NSCA_BRANCH            nsca-2.10.2
-ENV NAGIOSTV_VERSION       0.8.7
+ENV NAGIOSTV_VERSION       0.9.2
 
 
 RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections  && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -249,6 +249,7 @@ RUN echo "broker_module=/usr/local/lib/mk-livestatus/livestatus.o /usr/local/nag
 RUN cd /opt                                                                                           && \
     git clone --depth 1 --branch nagvis-${NAGVIS_VERSION} https://github.com/NagVis/nagvis.git nagvis && \
     cp nagvis/etc/nagvis.ini.php-sample nagvis/etc/nagvis.ini.php                                     && \
+    cp -r docs/ share/                                                                                && \
     sed -ie 's%^socket=.*$%socket="/usr/local/nagios/var/rw/live"%' nagvis/etc/nagvis.ini.php         && \
     cp nagvis/etc/apache2-nagvis.conf-sample /etc/apache2/conf-available/apache2-nagvis.conf          && \
     sed -ie 's%@NAGIOS_PATH@%/opt/nagios%g' /etc/apache2/conf-available/apache2-nagvis.conf           && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,14 @@ ENV NG_NAGIOS_CONFIG_FILE  ${NAGIOS_HOME}/etc/nagios.cfg
 ENV NG_CGI_DIR             ${NAGIOS_HOME}/sbin
 ENV NG_WWW_DIR             ${NAGIOS_HOME}/share/nagiosgraph
 ENV NG_CGI_URL             /cgi-bin
-ENV NAGIOS_BRANCH          nagios-4.5.9
+ENV NAGIOS_BRANCH          nagios-4.5.11
 ENV NAGIOS_PLUGINS_BRANCH  release-2.4.12
 ENV NRPE_BRANCH            nrpe-4.1.3
-ENV NCPA_BRANCH            v3.1.2
+ENV NCPA_BRANCH            v3.2.2
 ENV NSCA_BRANCH            nsca-2.10.3
-ENV NAGIOSTV_VERSION       0.9.2
+ENV NAGIOSTV_VERSION       0.9.8
 ENV MK_LIVESTATUS_VERSION  1.5.0p23
-ENV NAGVIS_VERSION         1.9.44
+ENV NAGVIS_VERSION         1.9.48
 
 
 RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections  && \
@@ -233,17 +233,18 @@ RUN cd /tmp && \
     tar xf nagiostv-${NAGIOSTV_VERSION}.tar.gz -C /opt/nagios/share/ && \
     rm /tmp/nagiostv-${NAGIOSTV_VERSION}.tar.gz
 
-RUN apt-get update && apt-get install -y libboost-all-dev
-RUN cd /tmp                                                                                && \
-    wget https://macro.int.pgmac.net/mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz         && \
-    tar zxf mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz                                  && \
-    cd mk_livestatus                                                                       && \
-    ./configure --with-nagios4                                                             && \
-    make                                                                                   && \
-    make install                                                                           && \
-    cd /tmp && rm -Rf mk_livestatus                                                        && \
-    cd /tmp && rm -f mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz
-RUN echo "broker_module=/usr/local/lib/mk-livestatus/livestatus.o /usr/local/nagios/var/rw/live" >> ${NAGIOS_HOME}/etc/nagios.cfg
+#RUN apt-get update && apt-get install -y libboost-all-dev
+#RUN cd /tmp                                                                                && \
+#    wget https://macro.int.pgmac.net/mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz         && \
+#    tar zxf mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz                                  && \
+#    cd mk_livestatus                                                                       && \
+#    ./configure --with-nagios4                                                             && \
+#    make                                                                                   && \
+#    make install                                                                           && \
+#    cd /tmp && rm -Rf mk_livestatus                                                        && \
+#    cd /tmp && rm -f mk-livestatus-${MK_LIVESTATUS_VERSION}.tar.gz
+#RUN echo "broker_module=/usr/local/lib/mk-livestatus/livestatus.o /usr/local/nagios/var/rw/live" >> ${NAGIOS_HOME}/etc/nagios.cfg
+COPY --from=checkmk/check-mk-raw:2.5.0-2025.01.31 /omd/sites/cmk/lib/mk-livestatus/livestatus.o /usr/local/lib/mk-livestatus/livestatus.o
 
 # Installing nagvis
 RUN cd /opt                                                                                           && \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Nagios Core 4.4.14 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
 
 | Product | Version |
 | ------- | ------- |
-| Nagios Core | 4.5.1 |
+| Nagios Core | 4.5.2 |
 | Nagios Plugins | 2.4.8 |
 | NRPE | 4.1.0 |
 | NCPA | 3.0.1 |

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Nagios Core 4.4.14 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
 
 | Product | Version |
 | ------- | ------- |
-| Nagios Core | 4.5.0 |
-| Nagios Plugins | 2.4.7 |
+| Nagios Core | 4.5.1 |
+| Nagios Plugins | 2.4.8 |
 | NRPE | 4.1.0 |
-| NCPA | 2.4.1 |
+| NCPA | 3.0.1 |
 | NSCA | 2.10.2 |
 
 ### Configurations

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Docker image for Nagios
 
 Build Status: [![Build Status](https://travis-ci.org/JasonRivers/Docker-Nagios.svg?branch=master)](https://travis-ci.org/JasonRivers/Docker-Nagios)
 
-Nagios Core 4.4.14 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
+Nagios Core 4.5.5 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
 
 | Product | Version |
 | ------- | ------- |
-| Nagios Core | 4.5.2 |
-| Nagios Plugins | 2.4.8 |
-| NRPE | 4.1.0 |
-| NCPA | 3.0.1 |
-| NSCA | 2.10.2 |
+| Nagios Core | 4.5.25|
+| Nagios Plugins | 2.4.12 |
+| NRPE | 4.1.1 |
+| NCPA | 3.1.1 |
+| NSCA | 2.10.3 |
 
 ### Configurations
 Nagios Configuration lives in /opt/nagios/etc

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Nagios Core 4.5.5 running on Ubuntu 22.04 LTS with NagiosGraph & NRPE
 
 | Product | Version |
 | ------- | ------- |
-| Nagios Core | 4.5.25|
+| Nagios Core | 4.5.9 |
 | Nagios Plugins | 2.4.12 |
-| NRPE | 4.1.1 |
-| NCPA | 3.1.1 |
+| NRPE | 4.1.3 |
+| NCPA | 3.1.2 |
 | NSCA | 2.10.3 |
 
 ### Configurations

--- a/overlay/etc/sv/xinetd/run
+++ b/overlay/etc/sv/xinetd/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec /usr/sbin/xinetd -f /etc/xinetd.conf -dontfork

--- a/overlay/etc/xinetd.d/livestatus
+++ b/overlay/etc/xinetd.d/livestatus
@@ -1,0 +1,14 @@
+service livestatus
+{
+    type        = UNLISTED
+    port        = 6557
+    socket_type = stream
+    protocol    = tcp
+    wait        = no
+    cps         = 100 3
+    flags       = NODELAY
+    user        = nagios
+    server      = /usr/local/bin/unixcat
+    server_args = /usr/local/nagios/var/rw/live
+    disable     = no
+}

--- a/overlay/opt/nagios/etc/nagios.cfg
+++ b/overlay/opt/nagios/etc/nagios.cfg
@@ -222,7 +222,7 @@ event_broker_options=-1
 
 #broker_module=/somewhere/module1.o
 #broker_module=/somewhere/module2.o arg1 arg2=3 debug=0
-
+broker_module=/usr/local/lib/mk-livestatus/livestatus.o /usr/local/nagios/var/rw/live event_broker_options=-1
 
 
 # LOG ROTATION METHOD

--- a/overlay/usr/local/bin/start_nagios
+++ b/overlay/usr/local/bin/start_nagios
@@ -14,6 +14,11 @@ if [ -z "$(ls -A /opt/nagios/var)" ]; then
     cp -Rp /orig/var/* /opt/nagios/var/
 fi
 
+if [ -z "$(ls -A /etc/xinetd.d)" ]; then
+    echo "Started with empty xinetd config, copying example data in-place"
+    cp -Rp /orig/xinetd.d/* /etc/xinetd.d/
+fi
+
 if [ ! -f "${NAGIOS_HOME}/etc/htpasswd.users" ] ; then
   htpasswd -c -b -s "${NAGIOS_HOME}/etc/htpasswd.users" "${NAGIOSADMIN_USER}" "${NAGIOSADMIN_PASS}"
   chown -R ${NAGIOS_USER}.${NAGIOS_GROUP} "${NAGIOS_HOME}/etc/htpasswd.users"
@@ -43,4 +48,3 @@ trap shutdown SIGTERM SIGHUP SIGINT
 wait "${RUNSVDIR}"
 
 shutdown
-

--- a/overlay/usr/local/bin/start_nagios
+++ b/overlay/usr/local/bin/start_nagios
@@ -14,6 +14,16 @@ if [ -z "$(ls -A /opt/nagios/var)" ]; then
     cp -Rp /orig/var/* /opt/nagios/var/
 fi
 
+if [ -z "$(ls -A /opt/nagiosgraph/etc)" ]; then
+    echo "Started with empty /opt/nagiosgraph/etc, copying example data in-place"
+    cp -Rp /orig/graph-etc/* /opt/nagiosgraph/etc/
+fi
+
+if [ -z "$(ls -A /opt/nagiosgraph/var)" ]; then
+    echo "Started with empty /opt/nagiosgraph/var, copying example data in-place"
+    cp -Rp /orig/graph-var/* /opt/nagiosgraph/var/
+fi
+
 # Cleanup unclean shutdown
 [ -f /var/run/apache2/apache2.pid ] && rm /var/run/apache2/apache2.pid
 [ -f /var/run/nsca.pid ] && rm /var/run/nsca.pid

--- a/overlay/usr/local/bin/start_nagios
+++ b/overlay/usr/local/bin/start_nagios
@@ -14,6 +14,10 @@ if [ -z "$(ls -A /opt/nagios/var)" ]; then
     cp -Rp /orig/var/* /opt/nagios/var/
 fi
 
+# Cleanup unclean shutdown
+[ -f /var/run/apache2/apache2.pid ] && rm /var/run/apache2/apache2.pid
+[ -f /var/run/nsca.pid ] && rm /var/run/nsca.pid
+
 if [ ! -f "${NAGIOS_HOME}/etc/htpasswd.users" ] ; then
   htpasswd -c -b -s "${NAGIOS_HOME}/etc/htpasswd.users" "${NAGIOSADMIN_USER}" "${NAGIOSADMIN_PASS}"
   chown -R ${NAGIOS_USER}.${NAGIOS_GROUP} "${NAGIOS_HOME}/etc/htpasswd.users"


### PR DESCRIPTION
## Summary
- Replaces inline \`slackapi/slack-github-action\` steps with centralised \`pg-actions\` reusable workflows
- Restructures single-job workflow into 3-job pattern: \`slack-start\` → build → \`slack-end\`
- Removes ~50 lines of duplicated timing, status, and Slack notification logic per repo

## Test plan
- [ ] Verify workflow triggers on next tag push
- [ ] Confirm Slack start notification appears when job begins
- [ ] Confirm Slack end notification updates with correct status and runtime
- [ ] Confirm build steps complete as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)